### PR TITLE
Fixes quantity field, initial PnL values, success message

### DIFF
--- a/src/main/java/trackr/logic/LogicManager.java
+++ b/src/main/java/trackr/logic/LogicManager.java
@@ -3,7 +3,6 @@ package trackr.logic;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
 import javafx.collections.ObservableList;
 import trackr.commons.core.GuiSettings;
@@ -18,7 +17,6 @@ import trackr.model.ReadOnlyMenu;
 import trackr.model.ReadOnlyOrderList;
 import trackr.model.ReadOnlySupplierList;
 import trackr.model.ReadOnlyTaskList;
-import trackr.model.menu.ItemPrice;
 import trackr.model.menu.ItemProfit;
 import trackr.model.menu.ItemSellingPrice;
 import trackr.model.menu.MenuItem;

--- a/src/main/java/trackr/logic/LogicManager.java
+++ b/src/main/java/trackr/logic/LogicManager.java
@@ -20,6 +20,7 @@ import trackr.model.ReadOnlySupplierList;
 import trackr.model.ReadOnlyTaskList;
 import trackr.model.menu.ItemPrice;
 import trackr.model.menu.ItemProfit;
+import trackr.model.menu.ItemSellingPrice;
 import trackr.model.menu.MenuItem;
 import trackr.model.order.Order;
 import trackr.model.person.Supplier;
@@ -107,17 +108,17 @@ public class LogicManager implements Logic {
         ObservableList<Order> allOrders = model.getFilteredOrderList();
         Double total = allOrders.stream()
                         .map(x -> x.getTotalProfit().getValue())
-                        .collect(Collectors.summingDouble(Double::doubleValue));
+                        .reduce(0.0, (subTotal, element) -> subTotal + element);
         return new ItemProfit(total);
     }
 
     @Override
-    public ItemPrice getTotalSales() {
+    public ItemSellingPrice getTotalSales() {
         ObservableList<Order> allOrders = model.getFilteredOrderList();
         Double total = allOrders.stream()
                         .map(x -> x.getTotalRevenue().getValue())
-                        .collect(Collectors.summingDouble(Double::doubleValue));
-        return new ItemPrice(total);
+                        .reduce(0.0, (subTotal, element) -> subTotal + element);
+        return new ItemSellingPrice(total);
     }
 
     @Override

--- a/src/main/java/trackr/logic/commands/EditItemCommand.java
+++ b/src/main/java/trackr/logic/commands/EditItemCommand.java
@@ -19,7 +19,7 @@ import trackr.model.item.ItemDescriptor;
  */
 public abstract class EditItemCommand<T extends Item> extends Command {
 
-    public static final String MESSAGE_EDIT_ITEM_SUCCESS = "Edited %s: %1$s";
+    public static final String MESSAGE_EDIT_ITEM_SUCCESS = "Edited %s: %2$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_ITEM = "This %1$s already exists in the %1$s list.";
 

--- a/src/main/java/trackr/logic/commands/EditItemCommand.java
+++ b/src/main/java/trackr/logic/commands/EditItemCommand.java
@@ -19,9 +19,9 @@ import trackr.model.item.ItemDescriptor;
  */
 public abstract class EditItemCommand<T extends Item> extends Command {
 
-    public static final String MESSAGE_EDIT_ITEM_SUCCESS = "Edited %s: %2$s";
+    public static final String MESSAGE_EDIT_ITEM_SUCCESS = "Edited %s: %s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_ITEM = "This %1$s already exists in the %1$s list.";
+    public static final String MESSAGE_DUPLICATE_ITEM = "This %s already exists in the %s list.";
 
     private final ModelEnum modelEnum;
     private final Index index;

--- a/src/main/java/trackr/logic/commands/EditItemCommand.java
+++ b/src/main/java/trackr/logic/commands/EditItemCommand.java
@@ -19,7 +19,7 @@ import trackr.model.item.ItemDescriptor;
  */
 public abstract class EditItemCommand<T extends Item> extends Command {
 
-    public static final String MESSAGE_EDIT_ITEM_SUCCESS = "Edited %s: %2$s";
+    public static final String MESSAGE_EDIT_ITEM_SUCCESS = "Edited %s: %s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_ITEM = "This %1$s already exists in the %1$s list.";
 

--- a/src/main/java/trackr/logic/commands/EditItemCommand.java
+++ b/src/main/java/trackr/logic/commands/EditItemCommand.java
@@ -19,9 +19,9 @@ import trackr.model.item.ItemDescriptor;
  */
 public abstract class EditItemCommand<T extends Item> extends Command {
 
-    public static final String MESSAGE_EDIT_ITEM_SUCCESS = "Edited %s: %s";
+    public static final String MESSAGE_EDIT_ITEM_SUCCESS = "Edited %s: %2$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_ITEM = "This %s already exists in the %s list.";
+    public static final String MESSAGE_DUPLICATE_ITEM = "This %1$s already exists in the %1$s list.";
 
     private final ModelEnum modelEnum;
     private final Index index;

--- a/src/main/java/trackr/logic/commands/order/EditOrderCommand.java
+++ b/src/main/java/trackr/logic/commands/order/EditOrderCommand.java
@@ -131,7 +131,7 @@ public class EditOrderCommand extends Command {
             throw new CommandException(String.format(MESSAGE_DUPLICATE_ITEM, ModelEnum.ORDER.toString().toLowerCase()));
         }
 
-        model.setItem(orderToEdit, editedOrder, ModelEnum.ORDER);
+        model.setItem(orderToEdit, validOrder, ModelEnum.ORDER);
         model.updateFilteredItemList(PREDICATE_SHOW_ALL_ITEMS, ModelEnum.ORDER);
         return new CommandResult(String.format(MESSAGE_EDIT_ITEM_SUCCESS, ModelEnum.ORDER.toString().toLowerCase(),
                 validOrder.toString()));

--- a/src/main/java/trackr/logic/commands/order/EditOrderCommand.java
+++ b/src/main/java/trackr/logic/commands/order/EditOrderCommand.java
@@ -39,10 +39,10 @@ import trackr.model.person.PersonPhone;
 public class EditOrderCommand extends Command {
     public static final String COMMAND_WORD = "edit_order";
     public static final String COMMAND_WORD_SHORTCUT = "edit_o";
-    public static final String MESSAGE_EDIT_ITEM_SUCCESS = "Edited %s: %1$s";
+    public static final String MESSAGE_EDIT_ITEM_SUCCESS = "Edited %s: %s";
     public static final String MESSAGE_NO_MENU_ITEM = "No such item in your menu.";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_ITEM = "This %1$s already exists in the %1$s list.";
+    public static final String MESSAGE_DUPLICATE_ITEM = "This %s already exists in the %s list.";
 
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the order identified "

--- a/src/main/java/trackr/model/menu/ItemPrice.java
+++ b/src/main/java/trackr/model/menu/ItemPrice.java
@@ -66,7 +66,7 @@ public class ItemPrice {
 
     @Override
     public String toString() {
-        return "" + formattedValue;
+        return formattedValue;
     }
 
     @Override

--- a/src/main/java/trackr/model/menu/ItemPrice.java
+++ b/src/main/java/trackr/model/menu/ItemPrice.java
@@ -66,7 +66,7 @@ public class ItemPrice {
 
     @Override
     public String toString() {
-        return "Price: $" + formattedValue;
+        return "" + formattedValue;
     }
 
     @Override

--- a/src/main/java/trackr/model/menu/ItemSellingPrice.java
+++ b/src/main/java/trackr/model/menu/ItemSellingPrice.java
@@ -13,6 +13,9 @@ public class ItemSellingPrice extends ItemPrice {
         super(value);
     }
 
+    public ItemSellingPrice(Double value) {
+        super(value);
+    }
     @Override
     public String toString() {
         return "Selling Price: $" + this.getFormattedValue();

--- a/src/main/java/trackr/model/menu/MenuItem.java
+++ b/src/main/java/trackr/model/menu/MenuItem.java
@@ -99,11 +99,11 @@ public class MenuItem extends Item {
     public String toString() {
         final StringBuilder builder = new StringBuilder();
         builder.append(getItemName())
-                .append("; Price: ")
+                .append("; ")
                 .append(getItemPrice())
-                .append("; Cost: ")
+                .append("; ")
                 .append(getItemCost())
-                .append("; Profit Margin: ")
+                .append("; ")
                 .append(getItemProfit());
         return builder.toString();
     }

--- a/src/main/java/trackr/model/order/Order.java
+++ b/src/main/java/trackr/model/order/Order.java
@@ -266,7 +266,7 @@ public class Order extends Item {
     public String toString() {
         final StringBuilder builder = new StringBuilder();
         builder.append(getOrderName())
-                .append("; Quantity: ")
+                .append("; ")
                 .append(getOrderQuantity())
                 .append("; Deadline: ")
                 .append(getOrderDeadline())

--- a/src/main/java/trackr/model/order/Order.java
+++ b/src/main/java/trackr/model/order/Order.java
@@ -250,7 +250,6 @@ public class Order extends Item {
         return otherOrder != null
                 && otherOrder.getCustomer().equals(this.getCustomer())
                 && otherOrder.getOrderName().equals(this.getOrderName())
-                && otherOrder.getOrderItem().equals(this.getOrderItem())
                 && otherOrder.getOrderDeadline().equals(this.getOrderDeadline())
                 && otherOrder.getOrderStatus().equals(this.getOrderStatus())
                 && otherOrder.getOrderQuantity().equals(this.getOrderQuantity());

--- a/src/main/java/trackr/model/order/OrderQuantity.java
+++ b/src/main/java/trackr/model/order/OrderQuantity.java
@@ -35,7 +35,7 @@ public class OrderQuantity {
 
     @Override
     public String toString() {
-        return value;
+        return "Quantity: " + value;
     }
 
     @Override

--- a/src/main/java/trackr/model/order/OrderQuantity.java
+++ b/src/main/java/trackr/model/order/OrderQuantity.java
@@ -33,6 +33,10 @@ public class OrderQuantity {
         return Integer.parseInt(value);
     }
 
+    public String getValue() {
+        return value;
+    }
+
     @Override
     public String toString() {
         return "Quantity: " + value;

--- a/src/main/java/trackr/model/order/OrderUtil.java
+++ b/src/main/java/trackr/model/order/OrderUtil.java
@@ -1,16 +1,18 @@
 package trackr.model.order;
 
 import trackr.model.menu.ItemPrice;
+import trackr.model.menu.ItemProfit;
+import trackr.model.menu.ItemSellingPrice;
 import trackr.model.menu.MenuItem;
 
 /**
  * Wrapper class to calculate financials based on Order and MenuItem
  */
 public class OrderUtil {
-    public static ItemPrice getTotalProfit(OrderQuantity qty, MenuItem item) {
+    public static ItemProfit getTotalProfit(OrderQuantity qty, MenuItem item) {
         int q = qty.getOrderQuantity();
         Double profit = q * item.getItemProfit().getValue();
-        return new ItemPrice(profit);
+        return new ItemProfit(profit);
     }
 
     public static ItemPrice getTotalCost(OrderQuantity qty, MenuItem item) {
@@ -19,9 +21,9 @@ public class OrderUtil {
         return new ItemPrice(cost);
     }
 
-    public static ItemPrice getTotalRevenue(OrderQuantity qty, MenuItem item) {
+    public static ItemSellingPrice getTotalRevenue(OrderQuantity qty, MenuItem item) {
         int q = qty.getOrderQuantity();
         Double revenue = q * item.getItemPrice().getValue();
-        return new ItemPrice(revenue);
+        return new ItemSellingPrice(revenue);
     }
 }

--- a/src/main/java/trackr/model/util/SampleDataUtil.java
+++ b/src/main/java/trackr/model/util/SampleDataUtil.java
@@ -123,20 +123,30 @@ public class SampleDataUtil {
                 new PersonPhone("71396482"),
                 new PersonAddress("789 Bonder Street"));
 
+        MenuItem cookie = new MenuItem(new ItemName("Chocolate Cookies"), 
+                                        new ItemSellingPrice("5.00"), 
+                                        new ItemCost("1.20"));
+        MenuItem cupcake = new MenuItem(new ItemName("Cupcake"), 
+                                        new ItemSellingPrice("6.20"), 
+                                        new ItemCost("1.10"));
+        MenuItem bracelet = new MenuItem(new ItemName("Bracelet"), 
+                                        new ItemSellingPrice("10"), 
+                                        new ItemCost("0.5"));
+
         return new Order[] {
-            new Order(new OrderName("Chocolate Cookies"),
+            new Order(cookie,
                     new OrderDeadline("01/01/2024"),
-                    new OrderStatus(), new OrderQuantity("2"),
+                    new OrderStatus(), new OrderQuantity("12"),
                     amy),
-            new Order(new OrderName("Cheese Cake"),
+            new Order(cupcake,
                     new OrderDeadline("03/03/2024"),
                     new OrderStatus("I"),
-                    new OrderQuantity("10"),
+                    new OrderQuantity("5"),
                     bob),
-            new Order(new OrderName("Vanilla Ice Cream"),
+            new Order(bracelet,
                     new OrderDeadline("02/01/2024"),
                     new OrderStatus("D"),
-                    new OrderQuantity("100"),
+                    new OrderQuantity("2"),
                     charlie)
         };
     }

--- a/src/main/java/trackr/model/util/SampleDataUtil.java
+++ b/src/main/java/trackr/model/util/SampleDataUtil.java
@@ -19,7 +19,6 @@ import trackr.model.menu.ItemSellingPrice;
 import trackr.model.menu.MenuItem;
 import trackr.model.order.Order;
 import trackr.model.order.OrderDeadline;
-import trackr.model.order.OrderName;
 import trackr.model.order.OrderQuantity;
 import trackr.model.order.OrderStatus;
 import trackr.model.person.Customer;
@@ -126,7 +125,7 @@ public class SampleDataUtil {
         MenuItem cookie = new MenuItem(new ItemName("Chocolate Cookies"),
                                         new ItemSellingPrice("5.00"),
                                         new ItemCost("1.20"));
-        MenuItem cupcake = new MenuItem(new ItemName("Cupcake"), 
+        MenuItem cupcake = new MenuItem(new ItemName("Cupcake"),
                                         new ItemSellingPrice("6.20"),
                                         new ItemCost("1.10"));
         MenuItem bracelet = new MenuItem(new ItemName("Bracelet"),

--- a/src/main/java/trackr/model/util/SampleDataUtil.java
+++ b/src/main/java/trackr/model/util/SampleDataUtil.java
@@ -99,7 +99,7 @@ public class SampleDataUtil {
         return new MenuItem[] {
             new MenuItem(new ItemName("Chocolate Cookies"), new ItemSellingPrice("5.00"), new ItemCost("1.20")),
             new MenuItem(new ItemName("Cupcake"), new ItemSellingPrice("6.20"), new ItemCost("1.10")),
-            new MenuItem(new ItemName("Bracelet"), new ItemSellingPrice("10"), new ItemCost("0.5"))
+            new MenuItem(new ItemName("Bread"), new ItemSellingPrice("10"), new ItemCost("0.5"))
         };
     }
 
@@ -128,7 +128,7 @@ public class SampleDataUtil {
         MenuItem cupcake = new MenuItem(new ItemName("Cupcake"),
                                         new ItemSellingPrice("6.20"),
                                         new ItemCost("1.10"));
-        MenuItem bracelet = new MenuItem(new ItemName("Bracelet"),
+        MenuItem bread = new MenuItem(new ItemName("Bread"),
                                         new ItemSellingPrice("10"),
                                         new ItemCost("0.5"));
 
@@ -142,7 +142,7 @@ public class SampleDataUtil {
                     new OrderStatus("I"),
                     new OrderQuantity("5"),
                     bob),
-            new Order(bracelet,
+            new Order(bread,
                     new OrderDeadline("02/01/2024"),
                     new OrderStatus("D"),
                     new OrderQuantity("2"),

--- a/src/main/java/trackr/model/util/SampleDataUtil.java
+++ b/src/main/java/trackr/model/util/SampleDataUtil.java
@@ -123,14 +123,14 @@ public class SampleDataUtil {
                 new PersonPhone("71396482"),
                 new PersonAddress("789 Bonder Street"));
 
-        MenuItem cookie = new MenuItem(new ItemName("Chocolate Cookies"), 
-                                        new ItemSellingPrice("5.00"), 
+        MenuItem cookie = new MenuItem(new ItemName("Chocolate Cookies"),
+                                        new ItemSellingPrice("5.00"),
                                         new ItemCost("1.20"));
         MenuItem cupcake = new MenuItem(new ItemName("Cupcake"), 
-                                        new ItemSellingPrice("6.20"), 
+                                        new ItemSellingPrice("6.20"),
                                         new ItemCost("1.10"));
-        MenuItem bracelet = new MenuItem(new ItemName("Bracelet"), 
-                                        new ItemSellingPrice("10"), 
+        MenuItem bracelet = new MenuItem(new ItemName("Bracelet"),
+                                        new ItemSellingPrice("10"),
                                         new ItemCost("0.5"));
 
         return new Order[] {

--- a/src/main/java/trackr/storage/JsonAdaptedOrder.java
+++ b/src/main/java/trackr/storage/JsonAdaptedOrder.java
@@ -1,15 +1,10 @@
 package trackr.storage;
 
-import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeParseException;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import trackr.commons.exceptions.IllegalValueException;
 import trackr.model.menu.MenuItem;
@@ -83,9 +78,6 @@ public class JsonAdaptedOrder {
      * Converts this Jackson-friendly adapted order object into the model's {@code Order} object.
      *
      * @throws IllegalValueException if there were any data constraints violated in the adapted order.
-     * @throws IOException
-     * @throws JsonMappingException
-     * @throws JsonParseException
      */
     public Order toModelType() throws IllegalValueException {
         if (customerName == null) {
@@ -120,6 +112,7 @@ public class JsonAdaptedOrder {
                     OrderName.class.getSimpleName()));
         }
 
+        // Guaranteed validity
         final MenuItem modelMenuItem = menuItem.toModelType();
 
         if (orderDeadline == null) {

--- a/src/main/java/trackr/storage/JsonAdaptedOrder.java
+++ b/src/main/java/trackr/storage/JsonAdaptedOrder.java
@@ -1,12 +1,18 @@
 package trackr.storage;
 
+import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeParseException;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import trackr.commons.exceptions.IllegalValueException;
+import trackr.model.menu.MenuItem;
 import trackr.model.order.Order;
 import trackr.model.order.OrderDeadline;
 import trackr.model.order.OrderName;
@@ -27,10 +33,11 @@ public class JsonAdaptedOrder {
             "Unexpected error encountered when parsing Order's `timeAdded` "
                     + "field that was read from storage file";
 
+
     private final String customerName;
     private final String customerPhone;
     private final String customerAddress;
-    private final String orderName;
+    private final JsonAdaptedMenuItem menuItem;
     private final String orderDeadline;
     private final String orderQuantity;
     private final String orderStatus;
@@ -43,7 +50,7 @@ public class JsonAdaptedOrder {
     public JsonAdaptedOrder(@JsonProperty("customerName") String customerName,
                            @JsonProperty("customerPhone") String customerPhone,
                            @JsonProperty("customerAddress") String customerAddress,
-                           @JsonProperty("orderName") String orderName,
+                           @JsonProperty("menuItem") JsonAdaptedMenuItem menuItem,
                            @JsonProperty("orderDeadline") String orderDeadline,
                            @JsonProperty("orderQuantity") String orderQuantity,
                            @JsonProperty("orderStatus") String orderStatus,
@@ -51,7 +58,7 @@ public class JsonAdaptedOrder {
         this.customerName = customerName;
         this.customerPhone = customerPhone;
         this.customerAddress = customerAddress;
-        this.orderName = orderName;
+        this.menuItem = menuItem;
         this.orderDeadline = orderDeadline;
         this.orderQuantity = orderQuantity;
         this.orderStatus = orderStatus;
@@ -65,7 +72,7 @@ public class JsonAdaptedOrder {
         customerName = source.getCustomer().getCustomerName().getName();
         customerPhone = source.getCustomer().getCustomerPhone().personPhone;
         customerAddress = source.getCustomer().getCustomerAddress().personAddress;
-        orderName = source.getOrderName().getName();
+        menuItem = new JsonAdaptedMenuItem(source.getOrderItem());
         orderDeadline = source.getOrderDeadline().toJsonString();
         orderQuantity = source.getOrderQuantity().value;
         orderStatus = source.getOrderStatus().toJsonString();
@@ -76,6 +83,9 @@ public class JsonAdaptedOrder {
      * Converts this Jackson-friendly adapted order object into the model's {@code Order} object.
      *
      * @throws IllegalValueException if there were any data constraints violated in the adapted order.
+     * @throws IOException
+     * @throws JsonMappingException
+     * @throws JsonParseException
      */
     public Order toModelType() throws IllegalValueException {
         if (customerName == null) {
@@ -105,14 +115,12 @@ public class JsonAdaptedOrder {
         }
         final PersonAddress modelAddress = new PersonAddress(customerAddress);
 
-        if (orderName == null) {
+        if (menuItem == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
                     OrderName.class.getSimpleName()));
         }
-        if (!OrderName.isValidName(orderName)) {
-            throw new IllegalValueException(OrderName.MESSAGE_CONSTRAINTS);
-        }
-        final OrderName modelOrderName = new OrderName(orderName);
+
+        final MenuItem modelMenuItem = menuItem.toModelType();
 
         if (orderDeadline == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
@@ -149,7 +157,7 @@ public class JsonAdaptedOrder {
         }
 
         Customer customer = new Customer(modelName, modelPhone, modelAddress);
-        return new Order(modelOrderName, modelOrderDeadline,
+        return new Order(modelMenuItem, modelOrderDeadline,
                 modelOrderStatus, modelOrderQuantity, customer, modelTimeAdded);
     }
 }

--- a/src/main/java/trackr/ui/MainWindow.java
+++ b/src/main/java/trackr/ui/MainWindow.java
@@ -3,6 +3,7 @@ package trackr.ui;
 import static trackr.commons.core.index.Index.fromZeroBased;
 import static trackr.logic.parser.TrackrParser.getModel;
 import static trackr.model.TabEnum.getTabIndex;
+import static trackr.ui.dashboard.TabPanel.clearSelection;
 import static trackr.ui.dashboard.TabPanel.switchToTab;
 
 import java.io.BufferedReader;
@@ -209,6 +210,7 @@ public class MainWindow extends UiPart<Stage> {
             CommandResult commandResult = logic.execute(commandText);
             logger.info("Result: " + commandResult.getFeedbackToUser());
             resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
+            switchToTab(fromZeroBased(getTabIndex(getModel(commandText))));
 
             if (commandResult.isShowHelp()) {
                 handleHelp();
@@ -217,9 +219,6 @@ public class MainWindow extends UiPart<Stage> {
             if (commandResult.isExit()) {
                 handleExit();
             }
-
-            switchToTab(fromZeroBased(getTabIndex(getModel(commandText))));
-
             return commandResult;
         } catch (CommandException | ParseException e) {
             logger.info("Invalid command: " + commandText);

--- a/src/main/java/trackr/ui/MainWindow.java
+++ b/src/main/java/trackr/ui/MainWindow.java
@@ -3,7 +3,6 @@ package trackr.ui;
 import static trackr.commons.core.index.Index.fromZeroBased;
 import static trackr.logic.parser.TrackrParser.getModel;
 import static trackr.model.TabEnum.getTabIndex;
-import static trackr.ui.dashboard.TabPanel.clearSelection;
 import static trackr.ui.dashboard.TabPanel.switchToTab;
 
 import java.io.BufferedReader;

--- a/src/main/java/trackr/ui/cards/OrderCard.java
+++ b/src/main/java/trackr/ui/cards/OrderCard.java
@@ -52,7 +52,7 @@ public class OrderCard extends UiPart<Region> {
         this.order = order;
         id.setText(displayedIndex + ". ");
         orderName.setText(order.getOrderName().getName());
-        orderQuantity.setText(order.getOrderQuantity().value);
+        orderQuantity.setText(order.getOrderQuantity().toString());
         orderDeadline.setText(order.getOrderDeadline().toString());
         orderStatus.setText(order.getOrderStatus().toString());
         customerName.setText(order.getCustomer().getCustomerName().getName());

--- a/src/main/java/trackr/ui/cards/SummarisedOrderCard.java
+++ b/src/main/java/trackr/ui/cards/SummarisedOrderCard.java
@@ -46,7 +46,7 @@ public class SummarisedOrderCard extends UiPart<Region> {
         this.order = order;
         id.setText(displayedIndex + ". ");
         orderName.setText(order.getOrderName().getName());
-        orderQuantity.setText(order.getOrderQuantity().value);
+        orderQuantity.setText(order.getOrderQuantity().toString());
         orderDeadline.setText(order.getOrderDeadline().toString());
         orderStatus.setText(order.getOrderStatus().toString());
         customerName.setText(order.getCustomer().getCustomerName().getName());

--- a/src/main/java/trackr/ui/dashboard/HomeView.java
+++ b/src/main/java/trackr/ui/dashboard/HomeView.java
@@ -76,7 +76,7 @@ public class HomeView extends UiPart<Region> {
         // event change listener to update revenue and profit
         logic.getFilteredOrderList().addListener(new ListChangeListener<Order>() {
             @Override
-            public void onChanged(ListChangeListener.Change change) {
+            public void onChanged(ListChangeListener.Change<? extends Order> change) {
                 profitPlaceholder.setText(logic.getTotalProfits().toString());
                 revenuePlaceholder.setText(logic.getTotalSales().toString());
             }

--- a/src/main/java/trackr/ui/dashboard/HomeView.java
+++ b/src/main/java/trackr/ui/dashboard/HomeView.java
@@ -73,6 +73,7 @@ public class HomeView extends UiPart<Region> {
         // Initial Revenue
         revenuePlaceholder.setText(logic.getTotalSales().toString());
 
+        // event change listener to update revenue and profit
         logic.getFilteredOrderList().addListener(new ListChangeListener<Order>() {
             @Override
             public void onChanged(ListChangeListener.Change change) {

--- a/src/main/java/trackr/ui/dashboard/TabPanel.java
+++ b/src/main/java/trackr/ui/dashboard/TabPanel.java
@@ -116,6 +116,10 @@ public class TabPanel extends UiPart<Region> {
         tabPanel.getSelectionModel().select(index.getZeroBased());
     }
 
+    public static void clearSelection() {
+        tabPanel.getSelectionModel().clearSelection();
+    }
+
     public SupplierListPanel getContactListPanel() {
         return contactListPanel;
     }

--- a/src/main/java/trackr/ui/dashboard/TabPanel.java
+++ b/src/main/java/trackr/ui/dashboard/TabPanel.java
@@ -113,7 +113,7 @@ public class TabPanel extends UiPart<Region> {
     }
 
     public static void switchToTab(Index index) {
-        tabPanel.getSelectionModel().select(index.getZeroBased());
+        tabPanel.getSelectionModel().clearAndSelect(index.getZeroBased());
     }
 
     public static void clearSelection() {

--- a/src/test/data/JsonSerializableTrackrTest/typicalOrdersTrackr.json
+++ b/src/test/data/JsonSerializableTrackrTest/typicalOrdersTrackr.json
@@ -3,22 +3,32 @@
     "suppliers": [ ],
     "tasks": [ ],
     "orders": [ {
-        "orderName": "Chocolate Cookies",
+        "customerName": "John Doe",
+        "customerPhone": "98765432",
+        "customerAddress": "123 Smith Street",
+        "menuItem": {
+            "itemName": "Chocolate Cookies",
+            "itemCost": "2.00",
+            "itemPrice": "5.00",
+            "itemProfit": "3.00"
+        },
         "orderDeadline": "01/01/2024",
         "orderStatus": "N",
-        "orderQuantity": "10",
-        "customerName": "John Doe",
-        "customerPhone": "12345678",
-        "customerAddress": "123 Smith Street",
+        "orderQuantity": "3",
         "timeAdded" : "2023-02-27T19:26:53.230822300"
     }, {
-        "orderName": "Cheese Cake",
-        "orderDeadline": "02/01/2024",
+        "customerName": "Mary Jane",
+        "customerPhone": "12345678",
+        "customerAddress": "321 Jurong Street",
+        "menuItem": {
+            "itemName": "Cupcakes",
+            "itemCost": "1.00",
+            "itemPrice": "3.00",
+            "itemProfit": "2.00"
+        },
+        "orderDeadline": "12/12/2024",
         "orderStatus": "N",
-        "orderQuantity": "2",
-        "customerName": "Amy Su",
-        "customerPhone": "87654321",
-        "customerAddress": "123 Bendy Street",
+        "orderQuantity": "10",
         "timeAdded" : "2023-03-18T14:49:22.368274900"
     } ],
     "menuItems": [ ]

--- a/src/test/java/trackr/logic/commands/FindOrderCommandTest.java
+++ b/src/test/java/trackr/logic/commands/FindOrderCommandTest.java
@@ -6,10 +6,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static trackr.commons.core.Messages.MESSAGE_ORDERS_LISTED_OVERVIEW;
 import static trackr.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static trackr.testutil.TypicalMenuItems.getTypicalMenu;
-import static trackr.testutil.TypicalOrders.CHEESE_CAKES;
-import static trackr.testutil.TypicalOrders.CHOCOLATE_COOKIES;
-import static trackr.testutil.TypicalOrders.DONUTS;
-import static trackr.testutil.TypicalOrders.VANILLA_CAKE;
+import static trackr.testutil.TypicalOrders.CARGO_PANTS_O;
+import static trackr.testutil.TypicalOrders.CHOCOLATE_COOKIES_O;
+import static trackr.testutil.TypicalOrders.CUPCAKE_O;
+import static trackr.testutil.TypicalOrders.NIKE_CAP_O;
 import static trackr.testutil.TypicalOrders.getTypicalOrderList;
 import static trackr.testutil.TypicalSuppliers.getTypicalSupplierList;
 import static trackr.testutil.TypicalTasks.getTypicalTaskList;
@@ -89,11 +89,11 @@ public class FindOrderCommandTest {
     @Test
     public void execute_multipleOrderNameKeywords_multipleOrdersFound() throws ParseException {
         String expectedMessage = String.format(MESSAGE_ORDERS_LISTED_OVERVIEW, 2);
-        OrderContainsKeywordsPredicate predicate = preparePredicate("Cheese Donuts", null, null);
+        OrderContainsKeywordsPredicate predicate = preparePredicate("Chocolate Cargo", null, null);
         FindOrderCommand command = new FindOrderCommand(predicate);
         expectedModel.updateFilteredItemList(predicate, ModelEnum.ORDER);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Arrays.asList(CHEESE_CAKES, DONUTS), model.getFilteredOrderList());
+        assertEquals(Arrays.asList(CHOCOLATE_COOKIES_O, CARGO_PANTS_O), model.getFilteredOrderList());
     }
 
     @Test
@@ -113,7 +113,7 @@ public class FindOrderCommandTest {
         FindOrderCommand command = new FindOrderCommand(predicate);
         expectedModel.updateFilteredItemList(predicate, ModelEnum.ORDER);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Arrays.asList(CHEESE_CAKES, CHOCOLATE_COOKIES), model.getFilteredOrderList());
+        assertEquals(Arrays.asList(CHOCOLATE_COOKIES_O, NIKE_CAP_O), model.getFilteredOrderList());
     }
 
     @Test
@@ -121,8 +121,8 @@ public class FindOrderCommandTest {
         String expectedMessage = String.format(MESSAGE_ORDERS_LISTED_OVERVIEW, 0);
         OrderContainsKeywordsPredicate predicate = preparePredicate(null, null, "D");
         FindOrderCommand command = new FindOrderCommand(predicate);
-        expectedModel.deleteItem(VANILLA_CAKE, ModelEnum.ORDER);
-        model.deleteItem(VANILLA_CAKE, ModelEnum.ORDER);
+        expectedModel.deleteItem(CARGO_PANTS_O, ModelEnum.ORDER);
+        model.deleteItem(CARGO_PANTS_O, ModelEnum.ORDER);
         expectedModel.updateFilteredItemList(predicate, ModelEnum.ORDER);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Collections.emptyList(), model.getFilteredOrderList());
@@ -135,7 +135,7 @@ public class FindOrderCommandTest {
         FindOrderCommand command = new FindOrderCommand(predicate);
         expectedModel.updateFilteredItemList(predicate, ModelEnum.ORDER);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Arrays.asList(CHEESE_CAKES, DONUTS, CHOCOLATE_COOKIES), model.getFilteredOrderList());
+        assertEquals(Arrays.asList(CHOCOLATE_COOKIES_O, CUPCAKE_O, NIKE_CAP_O), model.getFilteredOrderList());
     }
 
     /**

--- a/src/test/java/trackr/logic/parser/AddOrderCommandParserTest.java
+++ b/src/test/java/trackr/logic/parser/AddOrderCommandParserTest.java
@@ -2,7 +2,7 @@ package trackr.logic.parser;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static trackr.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static trackr.testutil.TypicalOrders.CHOCOLATE_COOKIES;
+import static trackr.testutil.TypicalOrders.CHOCOLATE_COOKIES_O;
 
 import org.junit.jupiter.api.Test;
 
@@ -15,7 +15,7 @@ public class AddOrderCommandParserTest {
 
     @Test
     public void parse_allFieldsPresent_success() {
-        Order expectedTask = new OrderBuilder(CHOCOLATE_COOKIES).build();
+        Order expectedTask = new OrderBuilder(CHOCOLATE_COOKIES_O).build();
 
         // whitespace only preamble
         assertTrue(expectedTask.equals(expectedTask));
@@ -24,7 +24,7 @@ public class AddOrderCommandParserTest {
     @Test
     public void parse_optionalFieldsMissing_success() {
         // no status
-        Order expectedTask = new OrderBuilder(CHOCOLATE_COOKIES).withOrderStatus().build();
+        Order expectedTask = new OrderBuilder(CHOCOLATE_COOKIES_O).withOrderStatus().build();
         assertTrue(expectedTask.equals(expectedTask));
     }
 

--- a/src/test/java/trackr/model/OrderListTest.java
+++ b/src/test/java/trackr/model/OrderListTest.java
@@ -3,24 +3,24 @@ package trackr.model;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-//import static trackr.logic.commands.CommandTestUtil.VALID_ORDER_STATUS_DONE;
+import static trackr.logic.commands.CommandTestUtil.VALID_ORDER_STATUS_DONE;
 import static trackr.testutil.Assert.assertThrows;
-import static trackr.testutil.TypicalOrders.CHEESE_CAKES;
-import static trackr.testutil.TypicalOrders.CHOCOLATE_COOKIES;
-//import static trackr.testutil.TypicalOrders.getTypicalOrderList;
+import static trackr.testutil.TypicalOrders.CUPCAKE_O;
+import static trackr.testutil.TypicalOrders.CHOCOLATE_COOKIES_O;
+import static trackr.testutil.TypicalOrders.getTypicalOrderList;
 
-//import java.util.Arrays;
-//import java.util.Collection;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
-//import java.util.List;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-//import javafx.collections.FXCollections;
-//import javafx.collections.ObservableList;`
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
 import trackr.model.item.exceptions.DuplicateItemException;
-//import trackr.model.order.Order;
-//import trackr.testutil.OrderBuilder;
+import trackr.model.order.Order;
+import trackr.testutil.OrderBuilder;
 
 public class OrderListTest {
 
@@ -36,22 +36,21 @@ public class OrderListTest {
         assertThrows(NullPointerException.class, () -> orderList.resetData(null));
     }
 
-    //    @Test
-    //    public void resetData_withValidReadOnlyOrderList_replacesData() {
-    //        OrderList newData = getTypicalOrderList();
-    //        orderList.resetData(newData);
-    //        assertEquals(newData, orderList);
-    //    }
-    //
-    //    @Test
-    //    public void resetData_withDuplicateOrders_throwsDuplicateOrderException() {
-    //        Order editedOrder = new OrderBuilder(CHOCOLATE_COOKIES)
-    //                .withOrderStatus(VALID_ORDER_STATUS_DONE).build();
-    //        List<Order> newOrders = Arrays.asList(CHOCOLATE_COOKIES, editedOrder);
-    //        OrderListStub newData = new OrderListStub(newOrders);
-    //
-    //        assertThrows(DuplicateItemException.class, () -> orderList.resetData(newData));
-    //    }
+    @Test
+    public void resetData_withValidReadOnlyOrderList_replacesData() {
+        OrderList newData = getTypicalOrderList();
+        orderList.resetData(newData);
+        assertEquals(newData, orderList);
+    }
+
+    @Test
+    public void resetData_withDuplicateOrders_throwsDuplicateOrderException() {
+        Order editedOrder = new OrderBuilder(CHOCOLATE_COOKIES_O)
+                .withOrderStatus(VALID_ORDER_STATUS_DONE).build();
+        List<Order> newOrders = Arrays.asList(CHOCOLATE_COOKIES_O, editedOrder);
+        OrderListStub newData = new OrderListStub(newOrders);
+        assertThrows(DuplicateItemException.class, () -> orderList.resetData(newData));
+    }
 
     @Test
     public void hasOrder_nullOrder_throwsNullPointerException() {
@@ -60,49 +59,49 @@ public class OrderListTest {
 
     @Test
     public void hasOrder_orderNotInOrderList_returnsFalse() {
-        assertFalse(orderList.hasItem(CHOCOLATE_COOKIES));
+        assertFalse(orderList.hasItem(CHOCOLATE_COOKIES_O));
     }
 
     @Test
     public void hasOrder_orderInOrderList_returnsTrue() {
-        orderList.addItem(CHOCOLATE_COOKIES);
-        assertTrue(orderList.hasItem(CHOCOLATE_COOKIES));
+        orderList.addItem(CHOCOLATE_COOKIES_O);
+        assertTrue(orderList.hasItem(CHOCOLATE_COOKIES_O));
     }
 
-    //    @Test
-    //    public void hasOrder_orderWithSameIdentityFieldsInOrderList_returnsTrue() {
-    //        orderList.addItem(CHOCOLATE_COOKIES);
-    //        Order editedOrder = new OrderBuilder(CHOCOLATE_COOKIES)
-    //                .withOrderStatus(VALID_ORDER_STATUS_DONE).build();
-    //        assertTrue(orderList.hasItem(editedOrder));
-    //    }
+    @Test
+    public void hasOrder_orderWithSameIdentityFieldsInOrderList_returnsTrue() {
+        orderList.addItem(CHOCOLATE_COOKIES_O);
+        Order editedOrder = new OrderBuilder(CHOCOLATE_COOKIES_O)
+                .withOrderStatus(VALID_ORDER_STATUS_DONE).build();
+        assertTrue(orderList.hasItem(editedOrder));
+    }
 
     @Test
     public void setOrderList_nullOrder_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> orderList.setItem(null, CHOCOLATE_COOKIES));
+        assertThrows(NullPointerException.class, () -> orderList.setItem(null, CHOCOLATE_COOKIES_O));
     }
 
     @Test
     public void setOrderList_nullEditedOrder_throwsNullPointerException() {
-        orderList.addItem(CHOCOLATE_COOKIES);
-        assertThrows(NullPointerException.class, () -> orderList.setItem(CHOCOLATE_COOKIES, null));
+        orderList.addItem(CHOCOLATE_COOKIES_O);
+        assertThrows(NullPointerException.class, () -> orderList.setItem(CHOCOLATE_COOKIES_O, null));
     }
 
     @Test
     public void setOrderList_withDuplicateOrders_throwsDuplicateOrderException() {
-        orderList.addItem(CHOCOLATE_COOKIES);
-        orderList.addItem(CHEESE_CAKES);
+        orderList.addItem(CHOCOLATE_COOKIES_O);
+        orderList.addItem(CUPCAKE_O);
         assertThrows(DuplicateItemException.class, () ->
-                orderList.setItem(CHEESE_CAKES, CHOCOLATE_COOKIES));
+                orderList.setItem(CUPCAKE_O, CHOCOLATE_COOKIES_O));
     }
 
     @Test
     public void setOrderList_withDifferentOrder_success() {
         OrderList expectedOrderList = new OrderList();
-        expectedOrderList.addItem(CHEESE_CAKES);
+        expectedOrderList.addItem(CUPCAKE_O);
 
-        orderList.addItem(CHOCOLATE_COOKIES);
-        orderList.setItem(CHOCOLATE_COOKIES, CHEESE_CAKES);
+        orderList.addItem(CHOCOLATE_COOKIES_O);
+        orderList.setItem(CHOCOLATE_COOKIES_O, CUPCAKE_O);
 
         assertEquals(expectedOrderList, orderList);
     }
@@ -114,13 +113,13 @@ public class OrderListTest {
 
     @Test
     public void equals() {
-        orderList.addItem(CHOCOLATE_COOKIES);
+        orderList.addItem(CHOCOLATE_COOKIES_O);
 
         OrderList differentOrderList = new OrderList();
-        differentOrderList.addItem(CHEESE_CAKES);
+        differentOrderList.addItem(CUPCAKE_O);
 
         OrderList sameOrderList = new OrderList();
-        sameOrderList.addItem(CHOCOLATE_COOKIES);
+        sameOrderList.addItem(CHOCOLATE_COOKIES_O);
 
         assertTrue(orderList.equals(orderList)); //same object
         assertTrue(orderList.equals(sameOrderList)); //contains the same tasks
@@ -130,16 +129,15 @@ public class OrderListTest {
         assertFalse(orderList.equals(1)); //different objects
     }
 
-    //    private static class OrderListStub implements ReadOnlyOrderList {
-    //        private final ObservableList<Order> orders = FXCollections.observableArrayList();
-    //
-    //        OrderListStub(Collection<Order> orders) {
-    //            this.orders.setAll(orders);
-    //        }
-    //
-    //        @Override
-    //        public ObservableList<Order> getItemList() {
-    //            return orders;
-    //        }
-    //    }
+    private static class OrderListStub implements ReadOnlyOrderList {
+        private final ObservableList<Order> orders = FXCollections.observableArrayList();
+        OrderListStub(Collection<Order> orders) {
+            this.orders.setAll(orders);
+        }
+
+        @Override
+        public ObservableList<Order> getItemList() {
+            return orders;
+        }
+    }
 }

--- a/src/test/java/trackr/model/OrderListTest.java
+++ b/src/test/java/trackr/model/OrderListTest.java
@@ -5,8 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static trackr.logic.commands.CommandTestUtil.VALID_ORDER_STATUS_DONE;
 import static trackr.testutil.Assert.assertThrows;
-import static trackr.testutil.TypicalOrders.CUPCAKE_O;
 import static trackr.testutil.TypicalOrders.CHOCOLATE_COOKIES_O;
+import static trackr.testutil.TypicalOrders.CUPCAKE_O;
 import static trackr.testutil.TypicalOrders.getTypicalOrderList;
 
 import java.util.Arrays;

--- a/src/test/java/trackr/model/order/OrderNameContainsKeywordPredicateTest.java
+++ b/src/test/java/trackr/model/order/OrderNameContainsKeywordPredicateTest.java
@@ -2,6 +2,7 @@ package trackr.model.order;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static trackr.testutil.TypicalMenuItems.CHOCOLATE_COOKIE_M;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -83,23 +84,23 @@ public class OrderNameContainsKeywordPredicateTest {
 
         // One keyword
         predicate =
-                new OrderPredicateBuilder().withOrderNameKeywords(Collections.singletonList("Buy")).build();
-        assertTrue(predicate.test(new OrderBuilder().withOrderName("Buy Food").build()));
+                new OrderPredicateBuilder().withOrderNameKeywords(Collections.singletonList("Chocolate")).build();
+        assertTrue(predicate.test(new OrderBuilder().withOrderItem(CHOCOLATE_COOKIE_M).build()));
 
         // Multiple keywords
         predicate =
-                new OrderPredicateBuilder().withOrderNameKeywords(Arrays.asList("Buy", "Food")).build();
-        assertTrue(predicate.test(new OrderBuilder().withOrderName("Buy Food").build()));
+                new OrderPredicateBuilder().withOrderNameKeywords(Arrays.asList("Chocolate", "Cookies")).build();
+        assertTrue(predicate.test(new OrderBuilder().withOrderItem(CHOCOLATE_COOKIE_M).build()));
 
         // Only one matching keyword
         predicate =
-                new OrderPredicateBuilder().withOrderNameKeywords(Arrays.asList("Buy", "flour")).build();
-        assertTrue(predicate.test(new OrderBuilder().withOrderName("Buy Food").build()));
+                new OrderPredicateBuilder().withOrderNameKeywords(Arrays.asList("Chocolate", "flour")).build();
+        assertTrue(predicate.test(new OrderBuilder().withOrderItem(CHOCOLATE_COOKIE_M).build()));
 
         // Mixed-case keywords
         predicate =
-                new OrderPredicateBuilder().withOrderNameKeywords(Arrays.asList("BuY", "FloUr")).build();
-        assertTrue(predicate.test(new OrderBuilder().withOrderName("Buy Flour").build()));
+                new OrderPredicateBuilder().withOrderNameKeywords(Arrays.asList("ChOcOlAtE", "CoOkiEs")).build();
+        assertTrue(predicate.test(new OrderBuilder().withOrderItem(CHOCOLATE_COOKIE_M).build()));
 
         // Deadline only
         predicate =
@@ -136,17 +137,17 @@ public class OrderNameContainsKeywordPredicateTest {
         // Zero keywords
         predicate =
                 new OrderPredicateBuilder().withOrderNameKeywords(Collections.emptyList()).build();
-        assertFalse(predicate.test(new OrderBuilder().withOrderName("Buy").build()));
+        assertFalse(predicate.test(new OrderBuilder().withOrderItem(CHOCOLATE_COOKIE_M).build()));
 
         // Non-matching keyword
         predicate =
                 new OrderPredicateBuilder().withOrderNameKeywords(Arrays.asList("Buy")).build();
-        assertFalse(predicate.test(new OrderBuilder().withOrderName("Sort Inventory").build()));
+        assertFalse(predicate.test(new OrderBuilder().withOrderItem(CHOCOLATE_COOKIE_M).build()));
 
         // Keywords match deadline and status, but does not match name
         predicate =
                 new OrderPredicateBuilder().withOrderNameKeywords(Arrays.asList("11/11/2024", "N")).build();
-        assertFalse(predicate.test(new OrderBuilder().withOrderName("Buy").withOrderDeadline("11/11/2024")
+        assertFalse(predicate.test(new OrderBuilder().withOrderItem(CHOCOLATE_COOKIE_M).withOrderDeadline("11/11/2024")
                 .withOrderStatus("N").build()));
 
         // Non-matching deadline
@@ -156,12 +157,12 @@ public class OrderNameContainsKeywordPredicateTest {
 
         // Match name and status, but not deadline
         predicate = new OrderPredicateBuilder()
-                .withOrderNameKeywords(Arrays.asList("Buy", "Flour"))
+                .withOrderNameKeywords(Arrays.asList("Chocolate", "Cookies"))
                 .withOrderStatus("N")
                 .withOrderDeadline("01/01/2023")
                 .build();
         testTask = new OrderBuilder()
-                .withOrderName("Buy Flour")
+                .withOrderItem(CHOCOLATE_COOKIE_M)
                 .withOrderStatus("N")
                 .withOrderDeadline("11/11/2023")
                 .build();
@@ -174,12 +175,12 @@ public class OrderNameContainsKeywordPredicateTest {
 
         // Match name and deadline, but not status
         predicate = new OrderPredicateBuilder()
-                .withOrderNameKeywords(Arrays.asList("Buy", "Flour"))
+                .withOrderNameKeywords(Arrays.asList("Chocolate", "Cookies"))
                 .withOrderStatus("N")
                 .withOrderDeadline("01/01/2023")
                 .build();
         testTask = new OrderBuilder()
-                .withOrderName("Buy Flour")
+                .withOrderItem(CHOCOLATE_COOKIE_M)
                 .withOrderStatus("D")
                 .withOrderDeadline("01/01/2023")
                 .build();
@@ -193,10 +194,10 @@ public class OrderNameContainsKeywordPredicateTest {
         // Same name and deadline
         predicate = new OrderPredicateBuilder()
                 .withOrderDeadline("01/01/2023")
-                .withOrderNameKeywords(Arrays.asList("Buy", "Food"))
+                .withOrderNameKeywords(Arrays.asList("Chocolate", "Cookies"))
                 .build();
         assertTrue(predicate.test(new OrderBuilder().withOrderDeadline("01/01/2023")
-                .withOrderName("Buy Food").build()));
+                .withOrderItem(CHOCOLATE_COOKIE_M).build()));
 
         // Same deadline and status
         predicate = new OrderPredicateBuilder()
@@ -207,11 +208,11 @@ public class OrderNameContainsKeywordPredicateTest {
 
         // Same name and status
         predicate = new OrderPredicateBuilder()
-                .withOrderNameKeywords(Arrays.asList("Buy", "Food"))
+                .withOrderNameKeywords(Arrays.asList("Chocolate", "Cookies"))
                 .withOrderStatus("N")
                 .build();
         Order testTask = new OrderBuilder()
-                .withOrderName("Buy Food")
+                .withOrderItem(CHOCOLATE_COOKIE_M)
                 .withOrderStatus("N")
                 .build();
         assertTrue(predicate.test(testTask));
@@ -224,12 +225,12 @@ public class OrderNameContainsKeywordPredicateTest {
 
         // Same name, different deadline and status
         predicate = new OrderPredicateBuilder()
-                .withOrderNameKeywords(Arrays.asList("Buy", "Food"))
+                .withOrderNameKeywords(Arrays.asList("Chocolate", "Cookies"))
                 .withOrderStatus("D")
                 .withOrderDeadline("11/11/2023")
                 .build();
         testTask = new OrderBuilder()
-                .withOrderName("Buy Food")
+                .withOrderItem(CHOCOLATE_COOKIE_M)
                 .withOrderStatus("N")
                 .withOrderDeadline("01/01/2023")
                 .build();
@@ -242,7 +243,7 @@ public class OrderNameContainsKeywordPredicateTest {
                 .withOrderDeadline("01/01/2023")
                 .build();
         testTask = new OrderBuilder()
-                .withOrderName("Buy Food")
+                .withOrderItem(CHOCOLATE_COOKIE_M)
                 .withOrderStatus("N")
                 .withOrderDeadline("01/01/2023")
                 .build();
@@ -255,7 +256,7 @@ public class OrderNameContainsKeywordPredicateTest {
                 .withOrderDeadline("01/01/2023")
                 .build();
         testTask = new OrderBuilder()
-                .withOrderName("Buy Food")
+                .withOrderItem(CHOCOLATE_COOKIE_M)
                 .withOrderStatus("N")
                 .withOrderDeadline("01/01/2023")
                 .build();
@@ -268,12 +269,12 @@ public class OrderNameContainsKeywordPredicateTest {
 
         // Same name, deadline and status
         predicate = new OrderPredicateBuilder()
-                .withOrderNameKeywords(Arrays.asList("Buy", "Food"))
+                .withOrderNameKeywords(Arrays.asList("Chocolate", "Cookies"))
                 .withOrderStatus("N")
                 .withOrderDeadline("01/01/2023")
                 .build();
         Order testTask = new OrderBuilder()
-                .withOrderName("Buy Food")
+                .withOrderItem(CHOCOLATE_COOKIE_M)
                 .withOrderStatus("N")
                 .withOrderDeadline("01/01/2023")
                 .build();
@@ -291,7 +292,7 @@ public class OrderNameContainsKeywordPredicateTest {
                 .withOrderDeadline("11/11/2023")
                 .build();
         Order testTask = new OrderBuilder()
-                .withOrderName("Buy Food")
+                .withOrderItem(CHOCOLATE_COOKIE_M)
                 .withOrderStatus("N")
                 .withOrderDeadline("01/01/2023")
                 .build();

--- a/src/test/java/trackr/model/order/OrderQuantityTest.java
+++ b/src/test/java/trackr/model/order/OrderQuantityTest.java
@@ -24,7 +24,7 @@ public class OrderQuantityTest {
         OrderQuantity orderQuantity = new OrderQuantity("123");
 
         assertTrue(Integer.toString(orderQuantity.hashCode()).equals(Integer.toString(orderQuantity.hashCode())));
-        assertTrue(orderQuantity.toString().equals("123"));
+        assertTrue(orderQuantity.toString().equals("Quantity: 123"));
 
 
         // null phone number

--- a/src/test/java/trackr/model/order/UniqueOrderListTest.java
+++ b/src/test/java/trackr/model/order/UniqueOrderListTest.java
@@ -5,8 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static trackr.logic.commands.CommandTestUtil.VALID_ORDER_STATUS_DONE;
 import static trackr.testutil.Assert.assertThrows;
-import static trackr.testutil.TypicalOrders.CUPCAKE_O;
 import static trackr.testutil.TypicalOrders.CHOCOLATE_COOKIES_O;
+import static trackr.testutil.TypicalOrders.CUPCAKE_O;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/src/test/java/trackr/model/order/UniqueOrderListTest.java
+++ b/src/test/java/trackr/model/order/UniqueOrderListTest.java
@@ -5,8 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static trackr.logic.commands.CommandTestUtil.VALID_ORDER_STATUS_DONE;
 import static trackr.testutil.Assert.assertThrows;
-import static trackr.testutil.TypicalOrders.CHEESE_CAKES;
-import static trackr.testutil.TypicalOrders.CHOCOLATE_COOKIES;
+import static trackr.testutil.TypicalOrders.CUPCAKE_O;
+import static trackr.testutil.TypicalOrders.CHOCOLATE_COOKIES_O;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -29,19 +29,19 @@ public class UniqueOrderListTest {
 
     @Test
     public void contains_orderNotInList_returnsFalse() {
-        assertFalse(uniqueOrderList.contains(CHOCOLATE_COOKIES));
+        assertFalse(uniqueOrderList.contains(CHOCOLATE_COOKIES_O));
     }
 
     @Test
     public void contains_orderInList_returnsTrue() {
-        uniqueOrderList.add(CHOCOLATE_COOKIES);
-        assertTrue(uniqueOrderList.contains(CHOCOLATE_COOKIES));
+        uniqueOrderList.add(CHOCOLATE_COOKIES_O);
+        assertTrue(uniqueOrderList.contains(CHOCOLATE_COOKIES_O));
     }
 
     //    @Test
     //    public void contains_orderWithSameIdentityFieldsInList_returnsTrue() {
-    //        uniqueOrderList.add(CHOCOLATE_COOKIES);
-    //        Order editedOrder = new OrderBuilder(CHOCOLATE_COOKIES)
+    //        uniqueOrderList.add(CHOCOLATE_COOKIES_O);
+    //        Order editedOrder = new OrderBuilder(CHOCOLATE_COOKIES_O)
     //                .withOrderStatus(VALID_ORDER_STATUS_DONE).build();
     //        assertTrue(uniqueOrderList.contains(editedOrder));
     //    }
@@ -53,43 +53,43 @@ public class UniqueOrderListTest {
 
     @Test
     public void add_duplicateOrder_throwsDuplicateOrderException() {
-        uniqueOrderList.add(CHOCOLATE_COOKIES);
-        assertThrows(DuplicateOrderException.class, () -> uniqueOrderList.add(CHOCOLATE_COOKIES));
+        uniqueOrderList.add(CHOCOLATE_COOKIES_O);
+        assertThrows(DuplicateOrderException.class, () -> uniqueOrderList.add(CHOCOLATE_COOKIES_O));
     }
 
     @Test
     public void setOrder_nullTargetOrder_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> uniqueOrderList.setOrder(null, CHOCOLATE_COOKIES));
+        assertThrows(NullPointerException.class, () -> uniqueOrderList.setOrder(null, CHOCOLATE_COOKIES_O));
     }
 
     @Test
     public void setOrder_nullEditedOrder_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> uniqueOrderList.setOrder(CHOCOLATE_COOKIES, null));
+        assertThrows(NullPointerException.class, () -> uniqueOrderList.setOrder(CHOCOLATE_COOKIES_O, null));
     }
 
     @Test
     public void setOrder_targetOrderNotInList_throwsOrderNotFoundException() {
         assertThrows(OrderNotFoundException.class, () ->
-                uniqueOrderList.setOrder(CHOCOLATE_COOKIES, CHOCOLATE_COOKIES));
+                uniqueOrderList.setOrder(CHOCOLATE_COOKIES_O, CHOCOLATE_COOKIES_O));
     }
 
     @Test
     public void setOrder_editedOrderIsSameOrder_success() {
-        uniqueOrderList.add(CHOCOLATE_COOKIES);
-        uniqueOrderList.setOrder(CHOCOLATE_COOKIES, CHOCOLATE_COOKIES);
+        uniqueOrderList.add(CHOCOLATE_COOKIES_O);
+        uniqueOrderList.setOrder(CHOCOLATE_COOKIES_O, CHOCOLATE_COOKIES_O);
 
         UniqueOrderList expectedUniqueOrderList = new UniqueOrderList();
-        expectedUniqueOrderList.add(CHOCOLATE_COOKIES);
+        expectedUniqueOrderList.add(CHOCOLATE_COOKIES_O);
 
         assertEquals(expectedUniqueOrderList, uniqueOrderList);
     }
 
     @Test
     public void setOrder_editedOrderHasSameIdentity_success() {
-        uniqueOrderList.add(CHOCOLATE_COOKIES);
-        Order editedOrder = new OrderBuilder(CHOCOLATE_COOKIES)
+        uniqueOrderList.add(CHOCOLATE_COOKIES_O);
+        Order editedOrder = new OrderBuilder(CHOCOLATE_COOKIES_O)
                 .withOrderStatus(VALID_ORDER_STATUS_DONE).build();
-        uniqueOrderList.setOrder(CHOCOLATE_COOKIES, editedOrder); //change task status
+        uniqueOrderList.setOrder(CHOCOLATE_COOKIES_O, editedOrder); //change task status
 
         UniqueOrderList expectedUniqueTaskList = new UniqueOrderList();
         expectedUniqueTaskList.add(editedOrder);
@@ -99,20 +99,20 @@ public class UniqueOrderListTest {
 
     @Test
     public void setOrder_editedOrderHasDifferentIdentity_success() {
-        uniqueOrderList.add(CHOCOLATE_COOKIES);
-        uniqueOrderList.setOrder(CHOCOLATE_COOKIES, CHEESE_CAKES);
+        uniqueOrderList.add(CHOCOLATE_COOKIES_O);
+        uniqueOrderList.setOrder(CHOCOLATE_COOKIES_O, CUPCAKE_O);
 
         UniqueOrderList expectedUniqueOrderList = new UniqueOrderList();
-        expectedUniqueOrderList.add(CHEESE_CAKES);
+        expectedUniqueOrderList.add(CUPCAKE_O);
 
         assertEquals(expectedUniqueOrderList, uniqueOrderList);
     }
 
     @Test
     public void setOrder_editedOrderHasNonUniqueIdentity_throwsDuplicateOrderException() {
-        uniqueOrderList.add(CHOCOLATE_COOKIES);
-        uniqueOrderList.add(CHEESE_CAKES);
-        assertThrows(DuplicateOrderException.class, () -> uniqueOrderList.setOrder(CHOCOLATE_COOKIES, CHEESE_CAKES));
+        uniqueOrderList.add(CHOCOLATE_COOKIES_O);
+        uniqueOrderList.add(CUPCAKE_O);
+        assertThrows(DuplicateOrderException.class, () -> uniqueOrderList.setOrder(CHOCOLATE_COOKIES_O, CUPCAKE_O));
     }
 
     @Test
@@ -122,13 +122,13 @@ public class UniqueOrderListTest {
 
     @Test
     public void remove_orderDoesNotExist_throwsOrderNotFoundException() {
-        assertThrows(OrderNotFoundException.class, () -> uniqueOrderList.remove(CHOCOLATE_COOKIES));
+        assertThrows(OrderNotFoundException.class, () -> uniqueOrderList.remove(CHOCOLATE_COOKIES_O));
     }
 
     @Test
     public void remove_existingOrder_removesOrder() {
-        uniqueOrderList.add(CHOCOLATE_COOKIES);
-        uniqueOrderList.remove(CHOCOLATE_COOKIES);
+        uniqueOrderList.add(CHOCOLATE_COOKIES_O);
+        uniqueOrderList.remove(CHOCOLATE_COOKIES_O);
 
         UniqueOrderList expectedUniqueOrderList = new UniqueOrderList();
 
@@ -142,10 +142,10 @@ public class UniqueOrderListTest {
 
     @Test
     public void setOrders_uniqueOrderList_replacesOwnListWithProvidedUniqueOrderList() {
-        uniqueOrderList.add(CHOCOLATE_COOKIES);
+        uniqueOrderList.add(CHOCOLATE_COOKIES_O);
 
         UniqueOrderList expectedUniqueTaskList = new UniqueOrderList();
-        expectedUniqueTaskList.add(CHEESE_CAKES);
+        expectedUniqueTaskList.add(CUPCAKE_O);
 
         uniqueOrderList.setOrders(expectedUniqueTaskList);
 
@@ -159,19 +159,19 @@ public class UniqueOrderListTest {
 
     @Test
     public void setOrders_list_replacesOwnListWithProvidedList() {
-        uniqueOrderList.add(CHOCOLATE_COOKIES);
-        List<Order> orderList = Collections.singletonList(CHEESE_CAKES);
+        uniqueOrderList.add(CHOCOLATE_COOKIES_O);
+        List<Order> orderList = Collections.singletonList(CUPCAKE_O);
         uniqueOrderList.setOrders(orderList);
 
         UniqueOrderList expectedUniqueOrderList = new UniqueOrderList();
-        expectedUniqueOrderList.add(CHEESE_CAKES);
+        expectedUniqueOrderList.add(CUPCAKE_O);
 
         assertEquals(expectedUniqueOrderList, uniqueOrderList);
     }
 
     @Test
     public void setOrders_listWithDuplicateOrders_throwsDuplicateTaskException() {
-        List<Order> listWithDuplicateOrders = Arrays.asList(CHOCOLATE_COOKIES, CHOCOLATE_COOKIES);
+        List<Order> listWithDuplicateOrders = Arrays.asList(CHOCOLATE_COOKIES_O, CHOCOLATE_COOKIES_O);
         assertThrows(DuplicateOrderException.class, () -> uniqueOrderList.setOrders(listWithDuplicateOrders));
     }
 

--- a/src/test/java/trackr/storage/JsonAdaptedOrderTest.java
+++ b/src/test/java/trackr/storage/JsonAdaptedOrderTest.java
@@ -4,13 +4,15 @@ package trackr.storage;
 import static trackr.storage.JsonAdaptedOrder.MISSING_FIELD_MESSAGE_FORMAT;
 import static trackr.testutil.Assert.assertThrows;
 import static trackr.testutil.TypicalCustomer.AMY;
-import static trackr.testutil.TypicalOrders.CHOCOLATE_COOKIES;
+import static trackr.testutil.TypicalMenuItems.INVALID_M;
+import static trackr.testutil.TypicalOrders.CHOCOLATE_COOKIES_O;
 
 import java.time.LocalDateTime;
 
 import org.junit.jupiter.api.Test;
 
 import trackr.commons.exceptions.IllegalValueException;
+import trackr.model.menu.MenuItem;
 import trackr.model.order.OrderDeadline;
 import trackr.model.order.OrderName;
 import trackr.model.order.OrderQuantity;
@@ -25,7 +27,7 @@ public class JsonAdaptedOrderTest {
     private static final String INVALID_CUSTOMER_PHONE = "+651234";
     private static final String INVALID_CUSTOMER_ADDRESS = " ";
     private static final String INVALID_ORDER_DEADLINE = "00/99/9999";
-    private static final String INVALID_ORDER_NAME = " ";
+    private static final MenuItem INVALID_ORDER_ITEM = INVALID_M;
     private static final String INVALID_ORDER_QUANTITY = "9999";
     private static final String INVALID_ORDER_STATUS = "T";
     private static final String INVALID_TIME_ADDED = "99/99/9999";
@@ -33,10 +35,10 @@ public class JsonAdaptedOrderTest {
     private static final String VALID_CUSTOMER_NAME = AMY.getCustomerName().toString();
     private static final String VALID_CUSTOMER_PHONE = AMY.getCustomerPhone().toString();
     private static final String VALID_CUSTOMER_ADDRESS = AMY.getCustomerAddress().toString();
-    private static final String VALID_ORDER_DEADLINE = CHOCOLATE_COOKIES.getOrderDeadline().toString();
-    private static final String VALID_ORDER_NAME = CHOCOLATE_COOKIES.getOrderName().toString();
-    private static final String VALID_ORDER_QUANTITY = CHOCOLATE_COOKIES.getOrderQuantity().toString();
-    private static final String VALID_ORDER_STATUS = CHOCOLATE_COOKIES.getOrderStatus().toJsonString();
+    private static final MenuItem VALID_ORDER_ITEM = CHOCOLATE_COOKIES_O.getOrderItem();
+    private static final String VALID_ORDER_DEADLINE = CHOCOLATE_COOKIES_O.getOrderDeadline().toString();
+    private static final String VALID_ORDER_QUANTITY = CHOCOLATE_COOKIES_O.getOrderQuantity().toString();
+    private static final String VALID_ORDER_STATUS = CHOCOLATE_COOKIES_O.getOrderStatus().toJsonString();
     private static final String VALID_TIME_ADDED = LocalDateTime.now().toString();
 
     //    @Test
@@ -49,7 +51,7 @@ public class JsonAdaptedOrderTest {
     public void toModelType_invalidCustomerName_throwsIllegalValueException() throws Exception {
         JsonAdaptedOrder order = new JsonAdaptedOrder(INVALID_CUSTOMER_NAME,
                 VALID_CUSTOMER_PHONE, VALID_CUSTOMER_ADDRESS,
-                VALID_ORDER_NAME, VALID_ORDER_DEADLINE, VALID_ORDER_QUANTITY,
+                new JsonAdaptedMenuItem(VALID_ORDER_ITEM), VALID_ORDER_DEADLINE, VALID_ORDER_QUANTITY,
                 VALID_ORDER_STATUS, VALID_TIME_ADDED);
         String expectedMessage = PersonName.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, order::toModelType);
@@ -58,7 +60,7 @@ public class JsonAdaptedOrderTest {
     @Test
     public void toModelType_nullCustomerName_throwsIllegalValueException() {
         JsonAdaptedOrder order = new JsonAdaptedOrder(null, VALID_CUSTOMER_PHONE,
-                VALID_CUSTOMER_ADDRESS, VALID_ORDER_NAME, VALID_ORDER_DEADLINE,
+                VALID_CUSTOMER_ADDRESS, new JsonAdaptedMenuItem(VALID_ORDER_ITEM), VALID_ORDER_DEADLINE,
                 VALID_ORDER_QUANTITY, VALID_ORDER_STATUS, VALID_TIME_ADDED);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT,
                 PersonName.class.getSimpleName());
@@ -69,7 +71,7 @@ public class JsonAdaptedOrderTest {
     public void toModelType_invalidCustomerPhone_throwsIllegalValueException() throws Exception {
         JsonAdaptedOrder order = new JsonAdaptedOrder(VALID_CUSTOMER_NAME,
                 INVALID_CUSTOMER_PHONE, VALID_CUSTOMER_ADDRESS,
-                VALID_ORDER_NAME, VALID_ORDER_DEADLINE, VALID_ORDER_QUANTITY,
+                new JsonAdaptedMenuItem(VALID_ORDER_ITEM), VALID_ORDER_DEADLINE, VALID_ORDER_QUANTITY,
                 VALID_ORDER_STATUS, VALID_TIME_ADDED);
         String expectedMessage = PersonPhone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, order::toModelType);
@@ -78,7 +80,7 @@ public class JsonAdaptedOrderTest {
     @Test
     public void toModelType_nullCustomerPhone_throwsIllegalValueException() {
         JsonAdaptedOrder order = new JsonAdaptedOrder(VALID_CUSTOMER_NAME, null,
-                VALID_CUSTOMER_ADDRESS, VALID_ORDER_NAME, VALID_ORDER_DEADLINE,
+                VALID_CUSTOMER_ADDRESS, new JsonAdaptedMenuItem(VALID_ORDER_ITEM), VALID_ORDER_DEADLINE,
                 VALID_ORDER_QUANTITY, VALID_ORDER_STATUS, VALID_TIME_ADDED);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT,
                 PersonPhone.class.getSimpleName());
@@ -89,7 +91,7 @@ public class JsonAdaptedOrderTest {
     public void toModelType_invalidCustomerAddress_throwsIllegalValueException() throws Exception {
         JsonAdaptedOrder order = new JsonAdaptedOrder(VALID_CUSTOMER_NAME,
                 VALID_CUSTOMER_PHONE, INVALID_CUSTOMER_ADDRESS,
-                VALID_ORDER_NAME, VALID_ORDER_DEADLINE, VALID_ORDER_QUANTITY,
+                new JsonAdaptedMenuItem(VALID_ORDER_ITEM), VALID_ORDER_DEADLINE, VALID_ORDER_QUANTITY,
                 VALID_ORDER_STATUS, VALID_TIME_ADDED);
         String expectedMessage = PersonAddress.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, order::toModelType);
@@ -98,7 +100,7 @@ public class JsonAdaptedOrderTest {
     @Test
     public void toModelType_nullCustomerAddress_throwsIllegalValueException() {
         JsonAdaptedOrder order = new JsonAdaptedOrder(VALID_CUSTOMER_NAME, VALID_CUSTOMER_PHONE,
-                null, VALID_ORDER_NAME, VALID_ORDER_DEADLINE,
+                null, new JsonAdaptedMenuItem(VALID_ORDER_ITEM), VALID_ORDER_DEADLINE,
                 VALID_ORDER_QUANTITY, VALID_ORDER_STATUS, VALID_TIME_ADDED);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT,
                 PersonAddress.class.getSimpleName());
@@ -106,16 +108,16 @@ public class JsonAdaptedOrderTest {
     }
 
     @Test
-    public void toModelType_invalidOrderName_throwsIllegalValueException() throws Exception {
+    public void toModelType_invalidOrderItem_throwsIllegalValueException() throws Exception {
         JsonAdaptedOrder order = new JsonAdaptedOrder(VALID_CUSTOMER_NAME, VALID_CUSTOMER_PHONE,
-                VALID_CUSTOMER_ADDRESS, INVALID_ORDER_NAME,
+                VALID_CUSTOMER_ADDRESS, new JsonAdaptedMenuItem(INVALID_ORDER_ITEM),
                 VALID_ORDER_DEADLINE, VALID_ORDER_QUANTITY, VALID_ORDER_STATUS, VALID_TIME_ADDED);
         String expectedMessage = OrderName.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, order::toModelType);
     }
 
     @Test
-    public void toModelType_nullOrderName_throwsIllegalValueException() {
+    public void toModelType_nullOrderItem_throwsIllegalValueException() {
         JsonAdaptedOrder order = new JsonAdaptedOrder(VALID_CUSTOMER_NAME, VALID_CUSTOMER_PHONE,
                 VALID_CUSTOMER_ADDRESS, null, VALID_ORDER_DEADLINE,
                 VALID_ORDER_QUANTITY, VALID_ORDER_STATUS, VALID_TIME_ADDED);
@@ -127,7 +129,7 @@ public class JsonAdaptedOrderTest {
     @Test
     public void toModelType_invalidOrderDeadline_throwsIllegalValueException() {
         JsonAdaptedOrder task = new JsonAdaptedOrder(VALID_CUSTOMER_NAME, VALID_CUSTOMER_PHONE,
-                VALID_CUSTOMER_ADDRESS, VALID_ORDER_NAME, INVALID_ORDER_DEADLINE,
+                VALID_CUSTOMER_ADDRESS, new JsonAdaptedMenuItem(VALID_ORDER_ITEM), INVALID_ORDER_DEADLINE,
                 VALID_ORDER_QUANTITY, VALID_ORDER_STATUS, VALID_TIME_ADDED);
         String expectedMessage = OrderDeadline.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, task::toModelType);
@@ -136,7 +138,7 @@ public class JsonAdaptedOrderTest {
     @Test
     public void toModelType_nullOrderDeadline_throwsIllegalValueException() {
         JsonAdaptedOrder order = new JsonAdaptedOrder(VALID_CUSTOMER_NAME, VALID_CUSTOMER_PHONE,
-                VALID_CUSTOMER_ADDRESS, VALID_ORDER_NAME, null,
+                VALID_CUSTOMER_ADDRESS, new JsonAdaptedMenuItem(VALID_ORDER_ITEM), null,
                 VALID_ORDER_QUANTITY, VALID_ORDER_STATUS, VALID_TIME_ADDED);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT,
                 OrderDeadline.class.getSimpleName());
@@ -147,7 +149,7 @@ public class JsonAdaptedOrderTest {
     public void toModelType_invalidOrderQuantity_throwsIllegalValueException() {
         JsonAdaptedOrder order =
                 new JsonAdaptedOrder(VALID_CUSTOMER_NAME, VALID_CUSTOMER_PHONE, VALID_CUSTOMER_ADDRESS,
-                        VALID_ORDER_NAME, "01/01/2024",
+                        new JsonAdaptedMenuItem(VALID_ORDER_ITEM), "01/01/2024",
                         INVALID_ORDER_QUANTITY, VALID_ORDER_STATUS, VALID_TIME_ADDED);
         String expectedMessage = OrderQuantity.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, order::toModelType);
@@ -156,7 +158,7 @@ public class JsonAdaptedOrderTest {
     @Test
     public void toModelType_nullOrderQuantity_throwsIllegalValueException() {
         JsonAdaptedOrder order = new JsonAdaptedOrder(VALID_CUSTOMER_NAME, VALID_CUSTOMER_PHONE,
-                VALID_CUSTOMER_ADDRESS, VALID_ORDER_NAME, "01/01/2024", null,
+                VALID_CUSTOMER_ADDRESS, new JsonAdaptedMenuItem(VALID_ORDER_ITEM), "01/01/2024", null,
                 VALID_ORDER_STATUS, VALID_TIME_ADDED);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT,
                 OrderQuantity.class.getSimpleName());
@@ -166,7 +168,7 @@ public class JsonAdaptedOrderTest {
     @Test
     public void toModelType_invalidOrderStatus_throwsIllegalValueException() {
         JsonAdaptedOrder order = new JsonAdaptedOrder(VALID_CUSTOMER_NAME, VALID_CUSTOMER_PHONE,
-                VALID_CUSTOMER_ADDRESS, VALID_ORDER_NAME, "01/01/2024",
+                VALID_CUSTOMER_ADDRESS, new JsonAdaptedMenuItem(VALID_ORDER_ITEM), VALID_ORDER_DEADLINE,
                 VALID_ORDER_QUANTITY, INVALID_ORDER_STATUS, VALID_TIME_ADDED);
         String expectedMessage = OrderStatus.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, order::toModelType);
@@ -175,7 +177,7 @@ public class JsonAdaptedOrderTest {
     @Test
     public void toModelType_nullOrderStatus_throwsIllegalValueException() {
         JsonAdaptedOrder order = new JsonAdaptedOrder(VALID_CUSTOMER_NAME, VALID_CUSTOMER_PHONE,
-                VALID_CUSTOMER_ADDRESS, VALID_ORDER_NAME, "01/01/2024",
+                VALID_CUSTOMER_ADDRESS, new JsonAdaptedMenuItem(VALID_ORDER_ITEM), VALID_ORDER_DEADLINE,
                 VALID_ORDER_QUANTITY, null, VALID_TIME_ADDED);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT,
                 OrderStatus.class.getSimpleName());
@@ -185,7 +187,7 @@ public class JsonAdaptedOrderTest {
     @Test
     public void toModelType_invalidTimeAdded_throwsIllegalValueException() {
         JsonAdaptedOrder order = new JsonAdaptedOrder(VALID_CUSTOMER_NAME, VALID_CUSTOMER_PHONE,
-                VALID_CUSTOMER_ADDRESS, VALID_ORDER_NAME, "01/01/2024",
+                VALID_CUSTOMER_ADDRESS, new JsonAdaptedMenuItem(VALID_ORDER_ITEM), VALID_ORDER_DEADLINE,
                 VALID_ORDER_QUANTITY, VALID_ORDER_STATUS, INVALID_TIME_ADDED);
         String expectedMessage = JsonAdaptedOrder.MESSAGE_PARSE_TIME_ADDED_ERROR;
         assertThrows(IllegalValueException.class, expectedMessage, order::toModelType);
@@ -194,7 +196,7 @@ public class JsonAdaptedOrderTest {
     @Test
     public void toModelType_nullTimeAdded_throwsIllegalValueException() {
         JsonAdaptedOrder order = new JsonAdaptedOrder(VALID_CUSTOMER_NAME, VALID_CUSTOMER_PHONE,
-                VALID_CUSTOMER_ADDRESS, VALID_ORDER_NAME, "01/01/2024",
+                VALID_CUSTOMER_ADDRESS, new JsonAdaptedMenuItem(VALID_ORDER_ITEM), VALID_ORDER_DEADLINE,
                 VALID_ORDER_QUANTITY, VALID_ORDER_STATUS, null);
         String expectedMessage = JsonAdaptedOrder.MESSAGE_PARSE_TIME_ADDED_ERROR;
         assertThrows(IllegalValueException.class, expectedMessage, order::toModelType);

--- a/src/test/java/trackr/storage/JsonAdaptedOrderTest.java
+++ b/src/test/java/trackr/storage/JsonAdaptedOrderTest.java
@@ -1,10 +1,10 @@
 package trackr.storage;
 
-//import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static trackr.storage.JsonAdaptedOrder.MISSING_FIELD_MESSAGE_FORMAT;
 import static trackr.testutil.Assert.assertThrows;
 import static trackr.testutil.TypicalCustomer.AMY;
-import static trackr.testutil.TypicalMenuItems.INVALID_M;
+import static trackr.testutil.InvalidMenuItem.createInvalidNameItem;
 import static trackr.testutil.TypicalOrders.CHOCOLATE_COOKIES_O;
 
 import java.time.LocalDateTime;
@@ -27,7 +27,6 @@ public class JsonAdaptedOrderTest {
     private static final String INVALID_CUSTOMER_PHONE = "+651234";
     private static final String INVALID_CUSTOMER_ADDRESS = " ";
     private static final String INVALID_ORDER_DEADLINE = "00/99/9999";
-    private static final MenuItem INVALID_ORDER_ITEM = INVALID_M;
     private static final String INVALID_ORDER_QUANTITY = "9999";
     private static final String INVALID_ORDER_STATUS = "T";
     private static final String INVALID_TIME_ADDED = "99/99/9999";
@@ -36,16 +35,16 @@ public class JsonAdaptedOrderTest {
     private static final String VALID_CUSTOMER_PHONE = AMY.getCustomerPhone().toString();
     private static final String VALID_CUSTOMER_ADDRESS = AMY.getCustomerAddress().toString();
     private static final MenuItem VALID_ORDER_ITEM = CHOCOLATE_COOKIES_O.getOrderItem();
-    private static final String VALID_ORDER_DEADLINE = CHOCOLATE_COOKIES_O.getOrderDeadline().toString();
-    private static final String VALID_ORDER_QUANTITY = CHOCOLATE_COOKIES_O.getOrderQuantity().toString();
+    private static final String VALID_ORDER_DEADLINE = "01/01/2024";
+    private static final String VALID_ORDER_QUANTITY = CHOCOLATE_COOKIES_O.getOrderQuantity().getValue();
     private static final String VALID_ORDER_STATUS = CHOCOLATE_COOKIES_O.getOrderStatus().toJsonString();
     private static final String VALID_TIME_ADDED = LocalDateTime.now().toString();
 
-    //    @Test
-    //    public void toModelType_validOrderDetails_returnsOrder() throws Exception {
-    //        JsonAdaptedOrder order = new JsonAdaptedOrder(CHOCOLATE_COOKIES);
-    //        assertEquals(CHOCOLATE_COOKIES, order.toModelType());
-    //    }
+    @Test
+    public void toModelType_validOrderDetails_returnsOrder() throws Exception {
+        JsonAdaptedOrder order = new JsonAdaptedOrder(CHOCOLATE_COOKIES_O);
+        assertEquals(CHOCOLATE_COOKIES_O, order.toModelType());
+    }
 
     @Test
     public void toModelType_invalidCustomerName_throwsIllegalValueException() throws Exception {
@@ -108,15 +107,6 @@ public class JsonAdaptedOrderTest {
     }
 
     @Test
-    public void toModelType_invalidOrderItem_throwsIllegalValueException() throws Exception {
-        JsonAdaptedOrder order = new JsonAdaptedOrder(VALID_CUSTOMER_NAME, VALID_CUSTOMER_PHONE,
-                VALID_CUSTOMER_ADDRESS, new JsonAdaptedMenuItem(INVALID_ORDER_ITEM),
-                VALID_ORDER_DEADLINE, VALID_ORDER_QUANTITY, VALID_ORDER_STATUS, VALID_TIME_ADDED);
-        String expectedMessage = OrderName.MESSAGE_CONSTRAINTS;
-        assertThrows(IllegalValueException.class, expectedMessage, order::toModelType);
-    }
-
-    @Test
     public void toModelType_nullOrderItem_throwsIllegalValueException() {
         JsonAdaptedOrder order = new JsonAdaptedOrder(VALID_CUSTOMER_NAME, VALID_CUSTOMER_PHONE,
                 VALID_CUSTOMER_ADDRESS, null, VALID_ORDER_DEADLINE,
@@ -149,7 +139,7 @@ public class JsonAdaptedOrderTest {
     public void toModelType_invalidOrderQuantity_throwsIllegalValueException() {
         JsonAdaptedOrder order =
                 new JsonAdaptedOrder(VALID_CUSTOMER_NAME, VALID_CUSTOMER_PHONE, VALID_CUSTOMER_ADDRESS,
-                        new JsonAdaptedMenuItem(VALID_ORDER_ITEM), "01/01/2024",
+                        new JsonAdaptedMenuItem(VALID_ORDER_ITEM), VALID_ORDER_DEADLINE,
                         INVALID_ORDER_QUANTITY, VALID_ORDER_STATUS, VALID_TIME_ADDED);
         String expectedMessage = OrderQuantity.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, order::toModelType);
@@ -158,7 +148,7 @@ public class JsonAdaptedOrderTest {
     @Test
     public void toModelType_nullOrderQuantity_throwsIllegalValueException() {
         JsonAdaptedOrder order = new JsonAdaptedOrder(VALID_CUSTOMER_NAME, VALID_CUSTOMER_PHONE,
-                VALID_CUSTOMER_ADDRESS, new JsonAdaptedMenuItem(VALID_ORDER_ITEM), "01/01/2024", null,
+                VALID_CUSTOMER_ADDRESS, new JsonAdaptedMenuItem(VALID_ORDER_ITEM), VALID_ORDER_DEADLINE, null,
                 VALID_ORDER_STATUS, VALID_TIME_ADDED);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT,
                 OrderQuantity.class.getSimpleName());

--- a/src/test/java/trackr/storage/JsonAdaptedOrderTest.java
+++ b/src/test/java/trackr/storage/JsonAdaptedOrderTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static trackr.storage.JsonAdaptedOrder.MISSING_FIELD_MESSAGE_FORMAT;
 import static trackr.testutil.Assert.assertThrows;
 import static trackr.testutil.TypicalCustomer.AMY;
-import static trackr.testutil.InvalidMenuItem.createInvalidNameItem;
 import static trackr.testutil.TypicalOrders.CHOCOLATE_COOKIES_O;
 
 import java.time.LocalDateTime;

--- a/src/test/java/trackr/testutil/InvalidMenuItem.java
+++ b/src/test/java/trackr/testutil/InvalidMenuItem.java
@@ -22,8 +22,6 @@ public class InvalidMenuItem {
     public static MenuItem createInvalidNameItem() throws IllegalArgumentException {
         final MenuItem invalidNameItem = new MenuItemBuilder()
             .withItemName(" ")
-            .withItemPrice("5.00")
-            .withItemCost("1.00")
             .build();
         return invalidNameItem;
     }
@@ -34,9 +32,8 @@ public class InvalidMenuItem {
      * @throws IllegalArgumentException
      */
     public static MenuItem createInvalidPriceItem() throws IllegalArgumentException {
-        final MenuItem invalidPriceItem = new MenuItemBuilder().withItemName(VALID_ORDER_NAME_CHOCOLATE_COOKIES)
+        final MenuItem invalidPriceItem = new MenuItemBuilder()
             .withItemPrice(" ")
-            .withItemCost("1.00")
             .build();
         return invalidPriceItem;
     }
@@ -48,8 +45,6 @@ public class InvalidMenuItem {
      */
     public static MenuItem createInvalidCostItem() throws IllegalArgumentException {
         final MenuItem invalidCostItem = new MenuItemBuilder()
-            .withItemName(VALID_ORDER_NAME_CHOCOLATE_COOKIES)
-            .withItemPrice("5.00")
             .withItemCost(" ")
             .build();
         return invalidCostItem;

--- a/src/test/java/trackr/testutil/InvalidMenuItem.java
+++ b/src/test/java/trackr/testutil/InvalidMenuItem.java
@@ -6,18 +6,14 @@ import trackr.model.menu.MenuItem;
 
 /**
  * An additional utility class that creates invalid {@code MenuItem}
- * 
- * @see TypicalMenuItems
+ *
  * However, since {@code TypicalMenuItems} is accessed statically, creating invalid menu items
- * in {@code TypicalMenuItems} will result in {@code IllegalArgumentException} 
+ * in {@code TypicalMenuItems} will result in {@code IllegalArgumentException}
  * from MenuItem checkArgument and will not be able to access other static methods such as {@see getTypicalMenu}
+ * Wrapper methods are necessary as IllegalArgumentException should only be thrown from relevant invalid field
+ * @see TypicalMenuItems
  */
 public class InvalidMenuItem {
-    /**
-     * Wrapper methods are necessary as IllegalArgumentException should only be thrown from
-     * relevant invalid field 
-     */
-
     /**
      * Wrapper method to Create an invalid menu item with invalid name
      * @return invalidMenuItem
@@ -31,16 +27,25 @@ public class InvalidMenuItem {
             .build();
         return invalidNameItem;
     }
-    
+
+    /**
+     * Wrapper method to Create an invalid menu item with invalid price
+     * @return invalidMenuItem
+     * @throws IllegalArgumentException
+     */
     public static MenuItem createInvalidPriceItem() throws IllegalArgumentException {
-        final MenuItem invalidPriceItem = new MenuItemBuilder()
-            .withItemName(VALID_ORDER_NAME_CHOCOLATE_COOKIES)
+        final MenuItem invalidPriceItem = new MenuItemBuilder().withItemName(VALID_ORDER_NAME_CHOCOLATE_COOKIES)
             .withItemPrice(" ")
             .withItemCost("1.00")
             .build();
         return invalidPriceItem;
     }
 
+    /**
+     * Wrapper method to Create an invalid menu item with invalid cost
+     * @return invalidMenuItem
+     * @throws IllegalArgumentException
+     */
     public static MenuItem createInvalidCostItem() throws IllegalArgumentException {
         final MenuItem invalidCostItem = new MenuItemBuilder()
             .withItemName(VALID_ORDER_NAME_CHOCOLATE_COOKIES)

--- a/src/test/java/trackr/testutil/InvalidMenuItem.java
+++ b/src/test/java/trackr/testutil/InvalidMenuItem.java
@@ -1,0 +1,52 @@
+package trackr.testutil;
+
+import static trackr.logic.commands.CommandTestUtil.VALID_ORDER_NAME_CHOCOLATE_COOKIES;
+
+import trackr.model.menu.MenuItem;
+
+/**
+ * An additional utility class that creates invalid {@code MenuItem}
+ * 
+ * @see TypicalMenuItems
+ * However, since {@code TypicalMenuItems} is accessed statically, creating invalid menu items
+ * in {@code TypicalMenuItems} will result in {@code IllegalArgumentException} 
+ * from MenuItem checkArgument and will not be able to access other static methods such as {@see getTypicalMenu}
+ */
+public class InvalidMenuItem {
+    /**
+     * Wrapper methods are necessary as IllegalArgumentException should only be thrown from
+     * relevant invalid field 
+     */
+
+    /**
+     * Wrapper method to Create an invalid menu item with invalid name
+     * @return invalidMenuItem
+     * @throws IllegalArgumentException
+     */
+    public static MenuItem createInvalidNameItem() throws IllegalArgumentException {
+        final MenuItem invalidNameItem = new MenuItemBuilder()
+            .withItemName(" ")
+            .withItemPrice("5.00")
+            .withItemCost("1.00")
+            .build();
+        return invalidNameItem;
+    }
+    
+    public static MenuItem createInvalidPriceItem() throws IllegalArgumentException {
+        final MenuItem invalidPriceItem = new MenuItemBuilder()
+            .withItemName(VALID_ORDER_NAME_CHOCOLATE_COOKIES)
+            .withItemPrice(" ")
+            .withItemCost("1.00")
+            .build();
+        return invalidPriceItem;
+    }
+
+    public static MenuItem createInvalidCostItem() throws IllegalArgumentException {
+        final MenuItem invalidCostItem = new MenuItemBuilder()
+            .withItemName(VALID_ORDER_NAME_CHOCOLATE_COOKIES)
+            .withItemPrice("5.00")
+            .withItemCost(" ")
+            .build();
+        return invalidCostItem;
+    }
+}

--- a/src/test/java/trackr/testutil/InvalidMenuItem.java
+++ b/src/test/java/trackr/testutil/InvalidMenuItem.java
@@ -1,7 +1,5 @@
 package trackr.testutil;
 
-import static trackr.logic.commands.CommandTestUtil.VALID_ORDER_NAME_CHOCOLATE_COOKIES;
-
 import trackr.model.menu.MenuItem;
 
 /**

--- a/src/test/java/trackr/testutil/MenuItemBuilder.java
+++ b/src/test/java/trackr/testutil/MenuItemBuilder.java
@@ -12,12 +12,12 @@ import trackr.model.menu.MenuItem;
 public class MenuItemBuilder {
 
     public static final String DEFAULT_ITEM_NAME = "Chocolate cookies";
-    public static final String DEFAULT_ITEM_COST = "1";
-    public static final String DEFAULT_ITEM_PRICE = "5";
+    public static final String DEFAULT_ITEM_PRICE = "5.00";
+    public static final String DEFAULT_ITEM_COST = "1.00";
 
     private ItemName itemName;
-    private ItemCost itemCost;
     private ItemSellingPrice itemPrice;
+    private ItemCost itemCost;
     private ItemProfit itemProfit;
 
     /**
@@ -25,8 +25,8 @@ public class MenuItemBuilder {
      */
     public MenuItemBuilder() {
         itemName = new ItemName(DEFAULT_ITEM_NAME);
-        itemCost = new ItemCost(DEFAULT_ITEM_COST);
         itemPrice = new ItemSellingPrice(DEFAULT_ITEM_PRICE);
+        itemCost = new ItemCost(DEFAULT_ITEM_COST);
         itemProfit = new ItemProfit(itemPrice, itemCost);
     }
 
@@ -35,8 +35,8 @@ public class MenuItemBuilder {
      */
     public MenuItemBuilder(MenuItem menuItemToCopy) {
         itemName = menuItemToCopy.getItemName();
-        itemCost = menuItemToCopy.getItemCost();
         itemPrice = menuItemToCopy.getItemPrice();
+        itemCost = menuItemToCopy.getItemCost();
     }
 
     /**

--- a/src/test/java/trackr/testutil/OrderBuilder.java
+++ b/src/test/java/trackr/testutil/OrderBuilder.java
@@ -1,8 +1,10 @@
 package trackr.testutil;
 
+import static trackr.testutil.TypicalMenuItems.CHOCOLATE_COOKIE_M;
+
+import trackr.model.menu.MenuItem;
 import trackr.model.order.Order;
 import trackr.model.order.OrderDeadline;
-import trackr.model.order.OrderName;
 import trackr.model.order.OrderQuantity;
 import trackr.model.order.OrderStatus;
 import trackr.model.person.Customer;
@@ -15,7 +17,7 @@ import trackr.model.person.PersonPhone;
  */
 public class OrderBuilder {
 
-    public static final String DEFAULT_ORDER_NAME = "Chocolate Cookies";
+    public static final MenuItem DEFAULT_ORDER_ITEM = CHOCOLATE_COOKIE_M;
     public static final String DEFAULT_ORDER_DEADLINE = "01/01/2027";
     public static final String DEFAULT_ORDER_QUANTITY = "3";
     public static final String DEFAULT_ORDER_STATUS = "N";
@@ -23,7 +25,7 @@ public class OrderBuilder {
     public static final String DEFAULT_CUSTOMER_PHONE = "98765432";
     public static final String DEFAULT_CUSTOMER_ADDRESS = "123 Main Street";
 
-    private OrderName orderName;
+    private MenuItem orderItem;
     private OrderQuantity orderQuantity;
     private OrderDeadline orderDeadline;
     private OrderStatus orderStatus;
@@ -35,7 +37,7 @@ public class OrderBuilder {
      * Creates a {@code OrderBuilder} with the default details.
      */
     public OrderBuilder() {
-        orderName = new OrderName(DEFAULT_ORDER_NAME);
+        orderItem = CHOCOLATE_COOKIE_M;
         orderQuantity = new OrderQuantity(DEFAULT_ORDER_QUANTITY);
         orderDeadline = new OrderDeadline(DEFAULT_ORDER_DEADLINE);
         orderStatus = new OrderStatus(DEFAULT_ORDER_STATUS);
@@ -48,7 +50,7 @@ public class OrderBuilder {
      * Initializes the OrderBuilder with the data of {@code orderToCopy}.
      */
     public OrderBuilder(Order orderToCopy) {
-        orderName = orderToCopy.getOrderName();
+        orderItem = orderToCopy.getOrderItem();
         orderQuantity = orderToCopy.getOrderQuantity();
         orderDeadline = orderToCopy.getOrderDeadline();
         orderStatus = orderToCopy.getOrderStatus();
@@ -60,8 +62,8 @@ public class OrderBuilder {
     /**
      * Sets the {@code OrderName} of the {@code Order} that we are building.
      */
-    public OrderBuilder withOrderName(String orderName) {
-        this.orderName = new OrderName(orderName);
+    public OrderBuilder withOrderItem(MenuItem orderItem) {
+        this.orderItem = orderItem;
         return this;
     }
 
@@ -126,7 +128,7 @@ public class OrderBuilder {
      */
     public Order build() {
         Customer c = new Customer(customerName, customerPhone, customerAddress);
-        return new Order(orderName, orderDeadline, orderStatus, orderQuantity, c);
+        return new Order(orderItem, orderDeadline, orderStatus, orderQuantity, c);
     }
 
 }

--- a/src/test/java/trackr/testutil/TypicalMenuItems.java
+++ b/src/test/java/trackr/testutil/TypicalMenuItems.java
@@ -45,11 +45,6 @@ public class TypicalMenuItems {
             .withItemCost("9.00")
             .build();
 
-    public static final MenuItem INVALID_M = new MenuItemBuilder().withItemName("Invalid Item")
-            .withItemPrice("0.00")
-            .withItemCost("0.00")
-            .build();
-
     private TypicalMenuItems() {} // prevents instantiation
 
     /**

--- a/src/test/java/trackr/testutil/TypicalMenuItems.java
+++ b/src/test/java/trackr/testutil/TypicalMenuItems.java
@@ -11,52 +11,49 @@ import trackr.model.Menu;
 import trackr.model.menu.MenuItem;
 
 /**
- * A utility class containing a list of {@code Task} objects to be used in tests.
+ * A utility class containing a list of {@code MenuItem} objects to be used in tests.
  */
 public class TypicalMenuItems {
 
     public static final MenuItem CHOCOLATE_COOKIE_M = new MenuItemBuilder()
             .withItemName(VALID_ORDER_NAME_CHOCOLATE_COOKIES)
-            .withItemPrice("5")
-            .withItemCost("2")
+            .withItemPrice("5.00")
+            .withItemCost("2.00")
             .build();
 
 
     public static final MenuItem CUPCAKE_M = new MenuItemBuilder().withItemName(VALID_ORDER_NAME_CUPCAKES)
-            .withItemPrice("3")
-            .withItemCost("1")
+            .withItemPrice("3.00")
+            .withItemCost("1.00")
             .build();
 
     public static final MenuItem HARLEY_SHIRT_M = new MenuItemBuilder().withItemName("Harley Davidson Shirt")
-            .withItemPrice("55")
-            .withItemCost("15")
+            .withItemPrice("55.00")
+            .withItemCost("15.00")
             .build();
 
 
     // Manually added
 
     public static final MenuItem CARGO_PANTS = new MenuItemBuilder().withItemName("Cargo Pants")
-            .withItemPrice("50")
-            .withItemCost("10")
+            .withItemPrice("50.00")
+            .withItemCost("10.00")
             .build();
 
-    // Manually added - Task's details found in {@code CommandTestUtil}
     public static final MenuItem NIKE_CAP = new MenuItemBuilder().withItemName("Nike Cap")
-            .withItemPrice("45")
-            .withItemCost("9")
+            .withItemPrice("45.00")
+            .withItemCost("9.00")
             .build();
 
-    public static final MenuItem INVALID_M = new MenuItemBuilder().withItemName("Invalid Itme")
-            .withItemPrice(null)
-            .withItemCost(null)
+    public static final MenuItem INVALID_M = new MenuItemBuilder().withItemName("Invalid Item")
+            .withItemPrice("0.00")
+            .withItemCost("0.00")
             .build();
-
-    public static final String KEYWORD_MATCHING_BUY = "Buy"; // A keyword that matches BUY
 
     private TypicalMenuItems() {} // prevents instantiation
 
     /**
-     * Returns an {@code TaskList} with all the typical tasks.
+     * Returns an {@code menu} with all the typical menu items.
      */
     public static Menu getTypicalMenu() {
         Menu menu = new Menu();

--- a/src/test/java/trackr/testutil/TypicalMenuItems.java
+++ b/src/test/java/trackr/testutil/TypicalMenuItems.java
@@ -46,6 +46,11 @@ public class TypicalMenuItems {
             .withItemCost("9")
             .build();
 
+    public static final MenuItem INVALID_M = new MenuItemBuilder().withItemName("Invalid Itme")
+            .withItemPrice(null)
+            .withItemCost(null)
+            .build();
+
     public static final String KEYWORD_MATCHING_BUY = "Buy"; // A keyword that matches BUY
 
     private TypicalMenuItems() {} // prevents instantiation

--- a/src/test/java/trackr/testutil/TypicalOrders.java
+++ b/src/test/java/trackr/testutil/TypicalOrders.java
@@ -9,7 +9,6 @@ import static trackr.logic.commands.CommandTestUtil.VALID_ORDER_STATUS_NOT_DONE;
 import static trackr.testutil.TypicalMenuItems.CARGO_PANTS;
 import static trackr.testutil.TypicalMenuItems.CHOCOLATE_COOKIE_M;
 import static trackr.testutil.TypicalMenuItems.CUPCAKE_M;
-import static trackr.testutil.TypicalMenuItems.INVALID_M;
 import static trackr.testutil.TypicalMenuItems.NIKE_CAP;
 
 import java.util.ArrayList;
@@ -50,14 +49,6 @@ public class TypicalOrders {
             .withCustomerAddress("456 Bedok Street").build();
 
     public static final Order NIKE_CAP_O = new OrderBuilder().withOrderItem(NIKE_CAP)
-            .withOrderDeadline(VALID_ORDER_DEADLINE_2024)
-            .withOrderStatus(VALID_ORDER_STATUS_NOT_DONE)
-            .withOrderQuantity(VALID_ORDER_QUANTITY_ONE)
-            .withCustomerName(VALID_CUSTOMER_NAME)
-            .withCustomerPhone(VALID_CUSTOMER_PHONE)
-            .withCustomerAddress(VALID_CUSTOMER_ADDRESS).build();
-
-    public static final Order INVALID_ORDER_ITEM = new OrderBuilder().withOrderItem(INVALID_M)
             .withOrderDeadline(VALID_ORDER_DEADLINE_2024)
             .withOrderStatus(VALID_ORDER_STATUS_NOT_DONE)
             .withOrderQuantity(VALID_ORDER_QUANTITY_ONE)

--- a/src/test/java/trackr/testutil/TypicalOrders.java
+++ b/src/test/java/trackr/testutil/TypicalOrders.java
@@ -4,9 +4,13 @@ import static trackr.logic.commands.CommandTestUtil.VALID_CUSTOMER_ADDRESS;
 import static trackr.logic.commands.CommandTestUtil.VALID_CUSTOMER_NAME;
 import static trackr.logic.commands.CommandTestUtil.VALID_CUSTOMER_PHONE;
 import static trackr.logic.commands.CommandTestUtil.VALID_ORDER_DEADLINE_2024;
-import static trackr.logic.commands.CommandTestUtil.VALID_ORDER_NAME_CHOCOLATE_COOKIES;
 import static trackr.logic.commands.CommandTestUtil.VALID_ORDER_QUANTITY_ONE;
 import static trackr.logic.commands.CommandTestUtil.VALID_ORDER_STATUS_NOT_DONE;
+import static trackr.testutil.TypicalMenuItems.CHOCOLATE_COOKIE_M;
+import static trackr.testutil.TypicalMenuItems.CUPCAKE_M;
+import static trackr.testutil.TypicalMenuItems.CARGO_PANTS;
+import static trackr.testutil.TypicalMenuItems.NIKE_CAP;
+import static trackr.testutil.TypicalMenuItems.INVALID_M;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -21,7 +25,7 @@ import trackr.model.order.Order;
  */
 public class TypicalOrders {
 
-    public static final Order CHEESE_CAKES = new OrderBuilder().withOrderName("Cheese Cakes")
+    public static final Order CHOCOLATE_COOKIES_O = new OrderBuilder().withOrderItem(CHOCOLATE_COOKIE_M)
             .withOrderDeadline("01/01/2024")
             .withOrderStatus("N")
             .withOrderQuantity("3")
@@ -29,7 +33,7 @@ public class TypicalOrders {
             .withCustomerPhone("98765432")
             .withCustomerAddress("123 Main Street").build();
 
-    public static final Order DONUTS = new OrderBuilder().withOrderName("Donuts")
+    public static final Order CUPCAKE_O = new OrderBuilder().withOrderItem(CUPCAKE_M)
             .withOrderDeadline("12/12/2024")
             .withOrderStatus("N")
             .withOrderQuantity("10")
@@ -37,7 +41,7 @@ public class TypicalOrders {
             .withCustomerPhone("12345678")
             .withCustomerAddress("321 Jurong Street").build();
 
-    public static final Order VANILLA_CAKE = new OrderBuilder().withOrderName("Vanilla Cake")
+    public static final Order CARGO_PANTS_O = new OrderBuilder().withOrderItem(CARGO_PANTS)
             .withOrderDeadline("31/12/2024")
             .withOrderStatus("D")
             .withOrderQuantity("100")
@@ -45,7 +49,15 @@ public class TypicalOrders {
             .withCustomerPhone("24681357")
             .withCustomerAddress("456 Bedok Street").build();
 
-    public static final Order CHOCOLATE_COOKIES = new OrderBuilder().withOrderName(VALID_ORDER_NAME_CHOCOLATE_COOKIES)
+    public static final Order NIKE_CAP_O = new OrderBuilder().withOrderItem(NIKE_CAP)
+            .withOrderDeadline(VALID_ORDER_DEADLINE_2024)
+            .withOrderStatus(VALID_ORDER_STATUS_NOT_DONE)
+            .withOrderQuantity(VALID_ORDER_QUANTITY_ONE)
+            .withCustomerName(VALID_CUSTOMER_NAME)
+            .withCustomerPhone(VALID_CUSTOMER_PHONE)
+            .withCustomerAddress(VALID_CUSTOMER_ADDRESS).build();
+
+    public static final Order INVALID_ORDER_ITEM = new OrderBuilder().withOrderItem(INVALID_M)
             .withOrderDeadline(VALID_ORDER_DEADLINE_2024)
             .withOrderStatus(VALID_ORDER_STATUS_NOT_DONE)
             .withOrderQuantity(VALID_ORDER_QUANTITY_ONE)
@@ -69,7 +81,7 @@ public class TypicalOrders {
     }
 
     public static List<Order> getTypicalOrders() {
-        return new ArrayList<>(Arrays.asList(CHEESE_CAKES, DONUTS, VANILLA_CAKE, CHOCOLATE_COOKIES));
+        return new ArrayList<>(Arrays.asList(CHOCOLATE_COOKIES_O, CUPCAKE_O, CARGO_PANTS_O, NIKE_CAP_O));
     }
 
 }

--- a/src/test/java/trackr/testutil/TypicalOrders.java
+++ b/src/test/java/trackr/testutil/TypicalOrders.java
@@ -6,11 +6,11 @@ import static trackr.logic.commands.CommandTestUtil.VALID_CUSTOMER_PHONE;
 import static trackr.logic.commands.CommandTestUtil.VALID_ORDER_DEADLINE_2024;
 import static trackr.logic.commands.CommandTestUtil.VALID_ORDER_QUANTITY_ONE;
 import static trackr.logic.commands.CommandTestUtil.VALID_ORDER_STATUS_NOT_DONE;
+import static trackr.testutil.TypicalMenuItems.CARGO_PANTS;
 import static trackr.testutil.TypicalMenuItems.CHOCOLATE_COOKIE_M;
 import static trackr.testutil.TypicalMenuItems.CUPCAKE_M;
-import static trackr.testutil.TypicalMenuItems.CARGO_PANTS;
-import static trackr.testutil.TypicalMenuItems.NIKE_CAP;
 import static trackr.testutil.TypicalMenuItems.INVALID_M;
+import static trackr.testutil.TypicalMenuItems.NIKE_CAP;
 
 import java.util.ArrayList;
 import java.util.Arrays;


### PR DESCRIPTION
Fixes #208, #238

1. Corrects the initial values of Profit-and-Revenue fields by changing `SampleDataUtil`
2. Corrects success message upon adding new menu item
3. Indicates Quantity tag as `Quantity: xx`
4. Corrects success messages on `edit` commands
5. [Unspotted bug] Order and Profit-and-Revenue field updates when quantity and order name fields of order is edited.

Note that 2. and 3. are not changes to Ui as it updates the `toString()` methods of the relevant classes.

---
Updates to `JsonAdaptedOrder`

JSON adapted for Order now nests `MenuItem`.

---
Refactors some test cases to test nested Order and MenuItem
