### PR TITLE
Reverts `Quantity` in cards and fix Tab Ui

### DIFF
--- a/src/main/java/trackr/logic/commands/TabCommand.java
+++ b/src/main/java/trackr/logic/commands/TabCommand.java
@@ -2,11 +2,11 @@ package trackr.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static trackr.logic.parser.CliSyntax.PREFIX_TAB;
-import static trackr.ui.dashboard.TabPanel.switchToTab;
 
 import trackr.commons.core.index.Index;
 import trackr.logic.commands.exceptions.CommandException;
 import trackr.model.Model;
+import trackr.model.ObservableTabIndex;
 
 /**
  * Switches to a tab specified by the user
@@ -32,7 +32,7 @@ public class TabCommand extends Command {
 
     @Override
     public CommandResult execute(Model unused) throws CommandException {
-        switchToTab(targetTab);
+        ObservableTabIndex.updateToTab(targetTab);
         return new CommandResult(String.format(MESSAGE_SUCCESS));
     }
 }

--- a/src/main/java/trackr/model/ObservableTabIndex.java
+++ b/src/main/java/trackr/model/ObservableTabIndex.java
@@ -1,0 +1,24 @@
+package trackr.model;
+
+import javafx.beans.property.IntegerProperty;
+import javafx.beans.property.SimpleIntegerProperty;
+import trackr.commons.core.index.Index;
+
+/**
+ * Observable value of selected tab that changes upon tab commands.
+ */
+public class ObservableTabIndex {
+    private static final SimpleIntegerProperty targetTabIndex = new SimpleIntegerProperty();
+
+    public static final IntegerProperty valueProperty() {
+        return targetTabIndex;
+    }
+
+    public static final void updateToTab(Index target) {
+        targetTabIndex.set(target.getZeroBased());
+    }
+
+    public static final int getTargetTab() {
+        return targetTabIndex.getValue();
+    }
+}

--- a/src/main/java/trackr/model/order/OrderQuantity.java
+++ b/src/main/java/trackr/model/order/OrderQuantity.java
@@ -39,7 +39,7 @@ public class OrderQuantity {
 
     @Override
     public String toString() {
-        return "Quantity: " + value;
+        return value;
     }
 
     @Override

--- a/src/main/java/trackr/ui/MainWindow.java
+++ b/src/main/java/trackr/ui/MainWindow.java
@@ -3,7 +3,6 @@ package trackr.ui;
 import static trackr.commons.core.index.Index.fromZeroBased;
 import static trackr.logic.parser.TrackrParser.getModel;
 import static trackr.model.TabEnum.getTabIndex;
-import static trackr.ui.dashboard.TabPanel.switchToTab;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -25,6 +24,7 @@ import trackr.logic.Logic;
 import trackr.logic.commands.CommandResult;
 import trackr.logic.commands.exceptions.CommandException;
 import trackr.logic.parser.exceptions.ParseException;
+import trackr.model.ObservableTabIndex;
 import trackr.ui.dashboard.TabPanel;
 
 /**
@@ -209,7 +209,7 @@ public class MainWindow extends UiPart<Stage> {
             CommandResult commandResult = logic.execute(commandText);
             logger.info("Result: " + commandResult.getFeedbackToUser());
             resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
-            switchToTab(fromZeroBased(getTabIndex(getModel(commandText))));
+            ObservableTabIndex.updateToTab(fromZeroBased(getTabIndex(getModel(commandText))));
 
             if (commandResult.isShowHelp()) {
                 handleHelp();

--- a/src/main/java/trackr/ui/dashboard/TabPanel.java
+++ b/src/main/java/trackr/ui/dashboard/TabPanel.java
@@ -1,12 +1,14 @@
 package trackr.ui.dashboard;
 
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableValue;
 import javafx.fxml.FXML;
 import javafx.scene.control.Tab;
 import javafx.scene.control.TabPane;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
-import trackr.commons.core.index.Index;
 import trackr.logic.Logic;
+import trackr.model.ObservableTabIndex;
 import trackr.ui.UiPart;
 import trackr.ui.listpanels.MenuListPanel;
 import trackr.ui.listpanels.OrderListPanel;
@@ -18,7 +20,6 @@ import trackr.ui.listpanels.TaskListPanel;
  */
 public class TabPanel extends UiPart<Region> {
     private static final String FXML = "TabPanel.fxml";
-    private static TabPane tabPanel;
 
     private Logic logic;
 
@@ -27,6 +28,9 @@ public class TabPanel extends UiPart<Region> {
     private TaskListPanel taskListPanel;
     private OrderListPanel orderListPanel;
     private MenuListPanel menuListPanel;
+
+    @FXML
+    private TabPane tabPanel;
 
     @FXML
     private Tab homeTab;
@@ -64,8 +68,13 @@ public class TabPanel extends UiPart<Region> {
     public TabPanel(Logic logic) {
         super(FXML);
         this.logic = logic;
-        tabPanel = new TabPane();
         fillTabs();
+        ObservableTabIndex.valueProperty().addListener(new ChangeListener<Number>() {
+            @Override
+            public void changed(ObservableValue<? extends Number> o, Number oldIdx, Number newIdx) {
+                switchToTab(newIdx.intValue());
+            }
+        });
     }
 
     /**
@@ -74,50 +83,44 @@ public class TabPanel extends UiPart<Region> {
     private void fillTabs() {
         homeView = new HomeView(logic);
         homePanelPlaceholder.getChildren().add(homeView.getRoot());
-        addNewTab(homeTab, homePanelPlaceholder, "Home");
+        fillNewTab(homeTab, homePanelPlaceholder, "Home");
 
         orderListPanel = new OrderListPanel(logic.getFilteredOrderList());
         orderListPanelPlaceholder
                 .getChildren()
                 .add(orderListPanel.getRoot());
-        addNewTab(orderTab, orderListPanelPlaceholder, "Orders");
+        fillNewTab(orderTab, orderListPanelPlaceholder, "Orders");
 
         taskListPanel = new TaskListPanel(logic.getFilteredTaskList());
         taskListPanelPlaceholder
                 .getChildren()
                 .add(taskListPanel.getRoot());
-        addNewTab(taskTab, taskListPanelPlaceholder, "Tasks");
+        fillNewTab(taskTab, taskListPanelPlaceholder, "Tasks");
 
         contactListPanel = new SupplierListPanel(logic.getFilteredSupplierList());
         contactListPanelPlaceholder
                 .getChildren()
                 .add(contactListPanel.getRoot());
-        addNewTab(contactTab, contactListPanelPlaceholder, "Contacts");
+        fillNewTab(contactTab, contactListPanelPlaceholder, "Contacts");
 
         // Create placeholder with text for menu
         menuListPanel = new MenuListPanel(logic.getFilteredMenu());
         menuListPanelPlaceholder
                 .getChildren()
                 .add(menuListPanel.getRoot());
-        addNewTab(menuTab, menuListPanelPlaceholder, "Menu");
+        fillNewTab(menuTab, menuListPanelPlaceholder, "Menu");
     }
 
     /**
      * Adds a {@code tab} with the given {@code tabContent} and {@code tabName}
      */
-    private void addNewTab(Tab tab, StackPane tabContent, String tabName) {
-        tab.setClosable(false);
+    private void fillNewTab(Tab tab, StackPane tabContent, String tabName) {
         tab.setText(tabName);
         tab.setContent(tabContent);
-        tabPanel.getTabs().add(tab);
     }
 
-    public static void switchToTab(Index index) {
-        tabPanel.getSelectionModel().clearAndSelect(index.getZeroBased());
-    }
-
-    public static void clearSelection() {
-        tabPanel.getSelectionModel().clearSelection();
+    public void switchToTab(int index) {
+        tabPanel.getSelectionModel().select(index);
     }
 
     public SupplierListPanel getContactListPanel() {

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -76,8 +76,8 @@ Styles TabPane that contains ListView of tasks and suppliers
 * Modifies tabs and its states
 */
 .tab {
-    -fx-background-color: -fx-background;
     -fx-background: #e1e1e1;
+    -fx-background-color: -fx-background;
     -fx-border-radius: 10 10 10 10;
     -fx-background-radius: 10;
     -fx-focus-color: transparent;

--- a/src/main/resources/view/TabPanel.fxml
+++ b/src/main/resources/view/TabPanel.fxml
@@ -3,33 +3,36 @@
 <?import javafx.scene.control.Tab?>
 <?import javafx.scene.control.TabPane?>
 <?import javafx.scene.layout.StackPane?>
+<?import javafx.scene.layout.StackPane?>
 
-<TabPane tabClosingPolicy="UNAVAILABLE" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1">
-    <tabs>
-        <Tab fx:id="homeTab" closable="false">
-            <content>
-                <StackPane fx:id="homePanelPlaceholder" alignment="TOP_CENTER" />
-            </content>
-        </Tab>
-        <Tab fx:id="orderTab">
-            <content>
-                <StackPane fx:id="orderListPanelPlaceholder" />
-            </content>
-        </Tab>
-        <Tab fx:id="taskTab">
-            <content>
-                <StackPane fx:id="taskListPanelPlaceholder" />
-            </content>
-        </Tab>
-        <Tab fx:id="contactTab">
-            <content>
-                <StackPane fx:id="contactListPanelPlaceholder" />
-            </content>
-        </Tab>
-        <Tab fx:id="menuTab">
-            <content>
-                <StackPane fx:id="menuListPanelPlaceholder" />
-            </content>
-        </Tab>
-    </tabs>
-</TabPane>
+<StackPane xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
+    <TabPane fx:id="tabPanel" tabClosingPolicy="UNAVAILABLE">
+        <tabs>
+            <Tab fx:id="homeTab" closable="false">
+                <content>
+                    <StackPane fx:id="homePanelPlaceholder" alignment="TOP_CENTER" />
+                </content>
+            </Tab>
+            <Tab fx:id="orderTab">
+                <content>
+                    <StackPane fx:id="orderListPanelPlaceholder" />
+                </content>
+            </Tab>
+            <Tab fx:id="taskTab">
+                <content>
+                    <StackPane fx:id="taskListPanelPlaceholder" />
+                </content>
+            </Tab>
+            <Tab fx:id="contactTab">
+                <content>
+                    <StackPane fx:id="contactListPanelPlaceholder" />
+                </content>
+            </Tab>
+            <Tab fx:id="menuTab">
+                <content>
+                    <StackPane fx:id="menuListPanelPlaceholder" />
+                </content>
+            </Tab>
+        </tabs>
+    </TabPane>
+</StackPane>

--- a/src/test/java/trackr/model/order/OrderQuantityTest.java
+++ b/src/test/java/trackr/model/order/OrderQuantityTest.java
@@ -24,7 +24,7 @@ public class OrderQuantityTest {
         OrderQuantity orderQuantity = new OrderQuantity("123");
 
         assertTrue(Integer.toString(orderQuantity.hashCode()).equals(Integer.toString(orderQuantity.hashCode())));
-        assertTrue(orderQuantity.toString().equals("Quantity: 123"));
+        assertTrue(orderQuantity.toString().equals("123"));
 
 
         // null phone number


### PR DESCRIPTION
Reverts changes to `OrderQuantity` as it is considered enhancement.

---

### Fixes switch tab behaviour 

#245, #260 

TabPane was initially accessed in a `static` way, which can cause issues with controllers in JavaFX. To change to `private` ref:
- Implement `ObservableTabIndex` which is an Observable value using JavaFX
- Listener/ Observer is added in `TabPanel`

Compared to previous iteration, this decouples `TabCommand` in Logic from `TabPanel` in Ui.